### PR TITLE
Change systemd unit to use `default.target`

### DIFF
--- a/contrib/oasis.service
+++ b/contrib/oasis.service
@@ -12,4 +12,4 @@ ExecStart=%s -l -c 'oasis --host localhost --port 4515 --no-open'
 Restart=on-failure
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION




**What is the purpose of this pull request?**

I was having a problem where I'd start my computer but the script wasn't
restarting automatically, and after some searching I found this: https://github.com/systemd/systemd/issues/2690#issuecomment-186973730

It looks like we should be using `default.target` instead of
`multi-user.target`.

**What changes did you make? (brief overview)**

Change systemd unit to use `default.target`

**Is there anything you'd like reviewers to focus on?**

Does this look right to you?