### PR TITLE
Add CLI flag for offline mode (using temporary hack with globals)

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,17 @@ const path = require('path')
 
 const config = yargs
   .env('OASIS')
+  .help('h')
+  .alias('h', 'help')
   .usage('Usage: $0 [options]')
   .options('open', {
-    describe: 'Automatically open app in web browser',
+    describe: 'Automatically open app in web browser.  Use --no-open to disable.',
     default: true,
+    type: 'boolean'
+  })
+  .options('offline', {
+    describe: "Don't try to connect to scuttlebutt peers or pubs",
+    default: false,
     type: 'boolean'
   })
   .options('host', {
@@ -41,6 +48,9 @@ process.argv = []
 if (config.debug) {
   process.env.DEBUG = 'oasis,oasis:*'
 }
+
+// Awful hack to get the offline config setting deep into src/pages/models/lib/server.js
+process.env.OASIS_OFFLINE = '' + config.offline
 
 const app = require('./src/app')
 

--- a/src/pages/models/lib/server.js
+++ b/src/pages/models/lib/server.js
@@ -1,5 +1,22 @@
 const ssbConfig = require('ssb-config')
 const flotilla = require('@fraction/flotilla')
+const debug = require('debug')('oasis')
 
-const server = flotilla({ ws: { http: false } })
+// Awful hack to get make offline CLI flag available here.
+// It's set in index.js
+const offline = process.env.OASIS_OFFLINE === 'true'
+if (offline) {
+  debug.enabled = true
+  debug('Offline mode activated - not connecting to scuttlebutt peers or pubs')
+}
+
+const server = flotilla({
+  conn: {
+    autostart: !offline
+  },
+  ws: {
+    http: false
+  }
+})
+
 server(ssbConfig)


### PR DESCRIPTION
This is a new offline branch (the old one `offline-mode` was pretty old, so I started over)

**What is the purpose of this pull request?**
Add `--offline` CLI flag which disables interaction with the SSB network by turning off the conn scheduler.  I believe, but am not 100% certain, this should cover all forms of peer discovery and pub communication.

**What changes did you make? (brief overview)**
* Add `--offline` CLI flag
* Get that config info into `server.js` using global variables 😦  since there isn't a way to pass the config down the dependency chain easily.  I tried to do the simplest thing that would work, expecting this to need cleanup later.
* In `server.js`, set `conn.autostart` to `false` when in offline mode
* Small improvements to CLI help text

**Is there anything you'd like reviewers to focus on?**
Going forward, we need a better way to get options down into `server.js`.  In the meantime is this hack acceptable?