### PR TITLE
filter messages outside time range

### DIFF
--- a/src/models/index.js
+++ b/src/models/index.js
@@ -629,7 +629,8 @@ module.exports = (cooler) => {
             return typeof msg.value.content === 'object' &&
         typeof msg.value.content.vote === 'object' &&
         typeof msg.value.content.vote.link === 'string' &&
-        typeof msg.value.content.vote.value === 'number'
+        typeof msg.value.content.vote.value === 'number' &&
+        msg.value.timestamp > earliest
           }),
           pull.reduce((acc, cur) => {
             const author = cur.value.author


### PR DESCRIPTION
**What's the problem you solved?**
If you stand up a fresh sbot and join a pub you get flooded with messages. Then your /popular/day shows you content from 2 years ago. I believe this to be happening because the `gt:` option is filtering on sync time and not message value time. 

After I made this change /popular/day was showing content from about a week ago in time. I assume this to be because of users interacting with week old content in the current day. I feel fine with this as a outcome.

**What solution are you recommending?**
Adding a message filter that filters on the timestamp inside the message.
