### PR TITLE
Add note about supported Node.js versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Most people should install Oasis with [npm](https://npmjs.org/).
 npm --global install @fraction/oasis@latest
 ```
 
+Please make sure that your Node.js version is the [**current** or **active LTS** release](https://nodejs.org/en/about/releases/).
+
 Want more? Check out [`install.md`](https://github.com/fraction/oasis/blob/master/docs/install.md).
 
 ## Resources


### PR DESCRIPTION
**What's the problem you solved?** I've had a few friends have trouble installing Oasis with an older version of Node.js.

**What solution are you recommending?** Add supported versions to the readme in a way that we don't have to update (like version numbers) and link to the Node.js website for people who want to learn more about the release schedule.