### PR TITLE
Create svg favicon

### DIFF
--- a/src/assets/favicon.svg
+++ b/src/assets/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 15">
+    <title>oasis favicon</title>
+    <text x="0" y="15">🏝️</text>
+</svg>

--- a/src/views/template.js
+++ b/src/views/template.js
@@ -23,10 +23,11 @@ module.exports = (...elements) => {
   const nodes =
     html({ lang: 'en' },
       head(
-        title('🏝️  Oasis'),
+        title('Oasis'),
         link({ rel: 'stylesheet', href: '/theme.css' }),
         link({ rel: 'stylesheet', href: '/assets/style.css' }),
         link({ rel: 'stylesheet', href: '/assets/highlight.css' }),
+        link({ rel: 'icon', type: 'image/svg+xml', href: '/assets/favicon.svg' }),
         meta({ charset: 'utf-8' }),
         meta({
           name: 'description',


### PR DESCRIPTION
**What's the problem you solved?**
When I pin the tab on firefox, the icon shown is generic. I'd love to see the DESERT ISLAND. Left is currently pinned, right is with this patch.

![favicon](https://user-images.githubusercontent.com/32407/72935644-bc4cd600-3d33-11ea-92c6-f14603722929.png)

**What solution are you recommending?**

Make an svg favicon. I'd be interested in seeing if it renders correctly in different browsers.
