### PR TITLE
Add help text in Meta about peer connections

### DIFF
--- a/src/views/index.js
+++ b/src/views/index.js
@@ -225,11 +225,13 @@ exports.metaView = ({ status, peers, theme, themeNames }) => {
         button({ type: 'submit' }, 'set theme')),
       base16Elements,
       h2('Status'),
-      h3('Indexes'),
-      progressElements,
+      h3('Peer Connections 💻⚡️💻'),
+      p('Your computer is syncing data with these other computers. It will connect to any scuttlebutt pub and peer it can find, even if you have no relationship with them, as it looks for data from your friends.'),
       peerList.length > 0
-        ? [h3('Peers'), ul(peerList)]
-        : null
+        ? ul(peerList)
+        : code('no peers connected'),
+      h3('Indexes'),
+      progressElements
     )
   )
 }


### PR DESCRIPTION
**What's the problem you solved?**
People are often confused about the difference between peer connections and social/following connections

**What solution are you recommending?**
* Added some help text on the Meta page Peers section as mentioned in #68.
* When there are no peers, say "no peers connected" instead of omitting the Peers section
* Moved Peers section before Indexes because I expect people to look at Peers more often than Indexes
