### PR TITLE
Add prototype for names in peer list

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -328,8 +328,14 @@ router
     const getMeta = async ({ theme }) => {
       const status = await meta.status()
       const peers = await meta.peers()
+      const peersWithNames = await Promise.all(
+        peers.map(async ([key, value]) => {
+          value.name = await about.name(value.key)
+          return [key, value]
+        })
+      )
 
-      return metaView({ status, peers, theme, themeNames })
+      return metaView({ status, peers: peersWithNames, theme, themeNames })
     }
     ctx.body = await getMeta({ theme })
   })

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -165,7 +165,7 @@ exports.metaView = ({ status, peers, theme, themeNames }) => {
       li(
         a(
           { href: `/author/${encodeURIComponent(data.key)}` },
-          code(data.key)
+          data.name
         )
       )
     )


### PR DESCRIPTION
**What's the problem you solved?** #68 

**What solution are you recommending?** This adds names to the peer list. I haven't tested what happens when we don't have someone's name. Maybe we should fall back to the first six characters of their name? Seems like maybe `about.name` should just return that instead of `null` maybe...