### PR TITLE
Make Travis faster by removing double-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ os:
   - osx
   - windows
 
-# This keeps Yarn from hanging the build.
-env:
-  - YARN_GPG=no
+# Don't build arbitrary branches, just pull requests + master + semver tags.
+branches:
+  only:
+  - master
+  - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/package.json
+++ b/package.json
@@ -2,12 +2,15 @@
   "name": "@fraction/oasis",
   "version": "2.11.0",
   "description": "friendly neighborhood scuttlebutt interface",
-  "repository": "git@github.com:fraction/oasis.git",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/fraction/oasis.git"
+  },
   "license": "AGPL-3.0",
   "author": "Christian Bundy <christianbundy@fraction.io>",
   "main": "src/index.js",
   "bin": {
-    "oasis": "./src/index.js"
+    "oasis": "src/index.js"
   },
   "scripts": {
     "dev": "nodemon --inspect src/index.js --debug --no-open",
@@ -42,7 +45,8 @@
     "ssb-msgs": "^5.2.0",
     "ssb-ref": "^2.13.9",
     "ssb-thread-schema": "^1.1.1",
-    "yargs": "^15.0.0"
+    "yargs": "^15.0.0",
+    "sharp": "^0.23.0"
   },
   "devDependencies": {
     "changelog-version": "^1.0.1",
@@ -54,5 +58,13 @@
   },
   "optionalDependencies": {
     "sharp": "^0.23.0"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/fraction/oasis/issues"
+  },
+  "homepage": "https://github.com/fraction/oasis#readme",
+  "directories": {
+    "doc": "docs"
+  },
+  "keywords": []
 }


### PR DESCRIPTION
**What's the problem you solved?** Travis builds PRs and branches, which means that local branches
get built twice (!).

**What solution are you recommending?**  Travis should only build `master`, and maybe tags. This commit also contains the changes from `npm --init`.