### PR TITLE
Change favicon dimensions to fit in tab

### DIFF
--- a/src/assets/favicon.svg
+++ b/src/assets/favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 15">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
     <title>oasis favicon</title>
-    <text x="0" y="15">🏝️</text>
+    <text x="0" y="14">🏝️</text>
 </svg>


### PR DESCRIPTION
**What's the problem you solved?** Some of the icon was being clipped in my browser. I think that this is because the SVG text actuall extends down under the line (like a `g` or `y`).

**What solution are you recommending?** Change SVG viewBox dimensions and SVG size to fit correctly.

Before and after:

![Screenshot from 2020-01-23 13-42-47](https://user-images.githubusercontent.com/537700/73026628-a51af080-3de6-11ea-80c7-2556ae01e25d.png)
