### PR TITLE
Use ssb-backlinks to improve /inbox page load

### DIFF
--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1036,22 +1036,22 @@ module.exports = cooler => {
 
       const options = configure(
         {
-          type: "post"
+          query: [{ $filter: { dest: ssb.id } }]
         },
         customOptions
       );
 
-      const source = await cooler.read(ssb.messagesByType, options);
+      const source = await cooler.read(ssb.backlinks.read, options);
 
       const messages = await new Promise((resolve, reject) => {
         pull(
           source,
+          // Make sure we're only getting private messages that are posts.
           pull.filter(
-            (
-              message // avoid private messages (!)
-            ) =>
+            message =>
               typeof message.value.content !== "string" &&
-              lodash.get(message, "value.meta.private")
+              lodash.get(message, "value.meta.private") &&
+              lodash.get(message, "value.content.type") === "post"
           ),
           pull.unique(message => {
             const { root } = message.value.content;


### PR DESCRIPTION
**What's the problem you solved?**

The /inbox page was being rendered super slowly because it was
reading through tons of messages.

**What solution are you recommending?**

There isn't a way to query the database for "private messages
for me", although maybe there should be, but one way we can get
something close is querying for "messages that reference me". Every
message that's encrypted for us will have a `.value.content.recps`
property that includes our feed ID, so we just have to filter out the
public messages and we're about 4 times faster than the previous
implementation.

```console
$ hyperfine 'curl -I http://localhost:4515/inbox' 'curl -I http://localhost:3000/inbox'
Benchmark #1: curl -I http://localhost:4515/inbox
  Time (mean ± σ):      3.352 s ±  0.093 s    [User: 2.0 ms, System: 4.3 ms]
  Range (min … max):    3.231 s …  3.483 s    10 runs

Benchmark #2: curl -I http://localhost:3000/inbox
  Time (mean ± σ):     811.8 ms ±  88.3 ms    [User: 2.7 ms, System: 2.9 ms]
  Range (min … max):   709.1 ms … 972.5 ms    10 runs

Summary
  'curl -I http://localhost:3000/inbox' ran
    4.13 ± 0.46 times faster than 'curl -I http://localhost:4515/inbox'
```

(I run my development server on port 3000 and the latest stable release on port 4515.)