### PR TITLE
Update Common-Good to stop using npm alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,11 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-      "dev": true,
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/core": {
@@ -125,10 +124,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
-      "dev": true,
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -345,9 +343,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.2.tgz",
-      "integrity": "sha512-B8emQA1qeKerqd1dmIsQYnXi+mmAzTB7flExjmy5X1aVAKFNNNDubkavwR13kR6JnpeLp3aLoJhwn9trWPAyFQ=="
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
+      "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -503,7 +501,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -625,9 +622,9 @@
       }
     },
     "bail": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
-      "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
       "dev": true
     },
     "balanced-match": {
@@ -888,9 +885,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001022",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001022.tgz",
-      "integrity": "sha512-FjwPPtt/I07KyLPkBQ0g7/XuZg6oUkYBVnPHNj3VHJbOjmmJ/GdSo/GUY6MwINEQvjhP6WZVbX8Tvms8xh0D5A==",
+      "version": "1.0.30001023",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
+      "integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -909,7 +906,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1153,14 +1149,13 @@
       }
     },
     "common-good": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/common-good/-/common-good-1.1.18.tgz",
-      "integrity": "sha512-5io4E28V+a2KHSvLzejKls8WpSi7yWxrPrWAyx5gm+FzGJhAcRI8WKpNpoiKy//+1yFgUjRG1tIVJKkCROoHCQ==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/common-good/-/common-good-1.1.19.tgz",
+      "integrity": "sha512-GqnB6XMEyurvPMzPuPYIpphBucNDvLW57LpKmd9SU8iLxD2ZE6R5wggJ22oUB7CxWUL/G7ctvbDe9BcHjD1adA==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.1",
-        "cspell": "^4.0.44",
-        "cspell-glob": "npm:cspell-glob-win-fix@^0.1.16",
+        "cspell": "^4.0.46",
         "dependency-check": "^4.1.0",
         "eslint": "^6.8.0",
         "lockfile-lint": "^3.0.8",
@@ -1464,15 +1459,15 @@
       "dev": true
     },
     "cspell": {
-      "version": "4.0.44",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-4.0.44.tgz",
-      "integrity": "sha512-xrjsRbAPyx0s4QOdZ7gDiEPlqKQV+ua47FOvFiZqtq16H082P2O/M9vnDdwiEK4j6ypJQT+GkmR5QVdXXp+1qw==",
+      "version": "4.0.46",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-4.0.46.tgz",
+      "integrity": "sha512-1OzY2LGMQmuoe4odLhabDAxQoPMMwYPCGFKSiJXPJIg+w50iSBpUy2fWu4ExLeMjIUt6jOZ9hTQsq6WRMyXq3g==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^2.20.3",
         "comment-json": "^1.1.3",
-        "cspell-glob": "^0.1.14",
+        "cspell-glob": "^0.1.17",
         "cspell-lib": "^4.1.14",
         "fs-extra": "^8.1.0",
         "gensequence": "^3.0.3",
@@ -1698,9 +1693,9 @@
       }
     },
     "cspell-glob": {
-      "version": "npm:cspell-glob-win-fix@0.1.16",
-      "resolved": "https://registry.npmjs.org/cspell-glob-win-fix/-/cspell-glob-win-fix-0.1.16.tgz",
-      "integrity": "sha512-Y3n5HoylY9yGBBvsSEQJ01VK2oM6lens0OCputxO4YYd/7xPv5dwbm0mbBiaFQMyaveqEsIFSHJGomQCrC3liw==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-0.1.17.tgz",
+      "integrity": "sha512-gAiKakWJbHay6cobcJnX1+XhNCFYqR7CJM5GPiEpRZ5RFXYR46fYbkVwTdg3sqbFLErJtghQj/0s5Xa0q9NJpQ==",
       "dev": true,
       "requires": {
         "micromatch": "^4.0.2"
@@ -2020,6 +2015,14 @@
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
+      }
+    },
+    "dotignore": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+      "requires": {
+        "minimatch": "^3.0.4"
       }
     },
     "duplexer2": {
@@ -2725,9 +2728,9 @@
       }
     },
     "flumelog-offset": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.4.3.tgz",
-      "integrity": "sha512-XG2uVxoMjwcWKHniKSp1Iyo4XSZqvpK/KcQNDfTUM+ajpehLveMTd5H0cXWzaVlNjkHE0oGDGL7CgHrDyixiIg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.4.4.tgz",
+      "integrity": "sha512-sakCD+dVx541h3VeVq3Ti2lWPRrJf8PBRmnbm9EMBVLJnZkS3UD2lAlClZROxgKbh/JkMPyffvhDGv4VHNCVbA==",
       "requires": {
         "aligned-block-file": "^1.2.0",
         "append-batch": "0.0.2",
@@ -3199,8 +3202,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-network2": {
       "version": "0.0.1",
@@ -3458,9 +3460,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.3.tgz",
-      "integrity": "sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
+      "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -3541,9 +3543,9 @@
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "is-alphabetical": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
       "dev": true
     },
     "is-alphanumeric": {
@@ -3553,9 +3555,9 @@
       "dev": true
     },
     "is-alphanumerical": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
       "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
@@ -3621,9 +3623,9 @@
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-decimal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
-      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
       "dev": true
     },
     "is-directory": {
@@ -3663,9 +3665,9 @@
       }
     },
     "is-hexadecimal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
     },
     "is-installed-globally": {
@@ -3808,9 +3810,9 @@
       "integrity": "sha512-N+XmAifLwbpAf6d5GM5DliNOZZrq2wnmdsAuhM2gyVaKAoJQIBz4emiPC4cnh4cIGiIqg0QvAa7sCpvGkN4WCg=="
     },
     "is-whitespace-character": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
-      "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
       "dev": true
     },
     "is-windows": {
@@ -3819,9 +3821,9 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "is-word-character": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
-      "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
       "dev": true
     },
     "is-wsl": {
@@ -3848,8 +3850,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -4398,9 +4399,9 @@
       }
     },
     "libnested": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/libnested/-/libnested-1.4.1.tgz",
-      "integrity": "sha512-7fvNHrU8QTep71gIJuz7z6iBAQULEHJOcIA0MKUlwFrSnntvOvnke+/tnR7ZxyRAQQ303UJXNZBSRz3r0N5tqw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/libnested/-/libnested-1.5.0.tgz",
+      "integrity": "sha512-IR5ASkAU4NHTN1JFeP9bYvhARhaBg8VD8yUcmvNIvFWg6L3dsM2yK1A9EM6MpPvWYKH9SEiljB59ZUa5s2pYnA=="
     },
     "libsodium": {
       "version": "0.7.6",
@@ -4490,9 +4491,9 @@
       }
     },
     "longest-streak": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
-      "integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
       "dev": true
     },
     "looper": {
@@ -4720,16 +4721,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
-        "mime-db": "1.42.0"
+        "mime-db": "1.43.0"
       }
     },
     "mimic-fn": {
@@ -4813,9 +4814,9 @@
       "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM="
     },
     "moo": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
     },
     "ms": {
       "version": "2.0.0",
@@ -4823,9 +4824,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multiblob": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/multiblob/-/multiblob-1.13.6.tgz",
-      "integrity": "sha512-1yKhCPwLXitdw3b3OF+SE0+vD06NGcL/7yumKWCrPkJaMdNv2gaO0lCukZaFKYyu05GimwXEynxGWPNBv5qbBA==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/multiblob/-/multiblob-1.13.7.tgz",
+      "integrity": "sha512-+vZLrxhuAJFOl9EFUkFviYpz8nIOdoM3Hzq8Mzx0uJkaRWd61QxIp68wglTM8ZtABXYgE0YowD98XqthCRxSow==",
       "requires": {
         "blake2s": "^1.0.1",
         "cont": "^1.0.1",
@@ -4842,13 +4843,6 @@
         "pull-write-file": "^0.2.1",
         "rimraf": "^2.2.8",
         "stream-to-pull-stream": "^1.7.2"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
-        }
       }
     },
     "multiblob-http": {
@@ -5005,12 +4999,12 @@
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
     },
     "nearley": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.0.tgz",
-      "integrity": "sha512-2v52FTw7RPqieZr3Gth1luAXZR7Je6q3KaDHY5bjl/paDUdMu35fZ8ICNgiYJRr3tf3NMvIQQR1r27AvEr9CRA==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.1.tgz",
+      "integrity": "sha512-xq47GIUGXxU9vQg7g/y1o1xuKnkO7ev4nRWqftmQrLkfnE/FjRqDaGOUakM8XHPn/6pW3bGjU2wgoJyId90rqg==",
       "requires": {
         "commander": "^2.19.0",
-        "moo": "^0.4.3",
+        "moo": "^0.5.0",
         "railroad-diagrams": "^1.0.0",
         "randexp": "0.4.6",
         "semver": "^5.4.1"
@@ -5483,10 +5477,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
-      "dev": true
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
     },
     "pify": {
       "version": "3.0.0",
@@ -6340,9 +6333,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6548,9 +6541,9 @@
       }
     },
     "resolve": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
-      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+      "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -7460,14 +7453,14 @@
       }
     },
     "ssb-plugins": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ssb-plugins/-/ssb-plugins-1.0.3.tgz",
-      "integrity": "sha512-Yo75otu2EYD193ezMwws2rkDo/h3QCiwp2Y4mfxJvK5wg69PB4/De3j+AJWamYQLyL85ge1bWQGcyJja1S+KPg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssb-plugins/-/ssb-plugins-1.0.4.tgz",
+      "integrity": "sha512-D48CcHdlkQwkFnaBmEQFt/rPDqHZ252JJ/dqAuFvdpFTnZ5ujYmdbIldOdBGcTm3Bn7GrRGmAGctOKwH/3X0dQ==",
       "requires": {
         "cross-spawn": "^6.0.5",
         "explain-error": "^1.0.4",
         "mkdirp": "^0.5.1",
-        "muxrpc": "^6.4.0",
+        "muxrpc": "^6.4.6",
         "muxrpc-validation": "^3.0.0",
         "mv": "^2.1.1",
         "osenv": "^0.1.5",
@@ -7545,9 +7538,9 @@
       }
     },
     "ssb-room": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ssb-room/-/ssb-room-1.1.1.tgz",
-      "integrity": "sha512-poV4vXJDuB/rJd48eDjqI57va5fJua160RgPvLahQfekNhW2ACdqqtyaOBpVTLC73U1znfv7PKX9omyf0ihztg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ssb-room/-/ssb-room-1.2.0.tgz",
+      "integrity": "sha512-WuBwYr5szFP9c7M1wk6WW/J+ByHB9MIpus4qVSFEes9NCmwStnLRJGeQZf6DnJe0M4rwddrwb6UUh4M/bApNNQ==",
       "requires": {
         "body-parser": "^1.16.0",
         "debug": "~4.1.1",
@@ -7562,17 +7555,12 @@
         "ssb-caps": "~1.1.0",
         "ssb-client": "~4.7.8",
         "ssb-config": "~3.3.2",
-        "ssb-conn": "~0.11.0",
+        "ssb-conn": ">=0.11.0",
         "ssb-logging": "~1.0.0",
         "ssb-master": "~1.0.3",
         "ssb-ref": "~2.13.9"
       },
       "dependencies": {
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
         "secret-stack": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.3.0.tgz",
@@ -8119,7 +8107,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -8177,12 +8164,13 @@
       }
     },
     "tape": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.12.1.tgz",
-      "integrity": "sha512-xoK2ariLmdGxqyXhhxfIZlr0czNB8hNJeVQmHN4D7ZyBn30GUoa4q2oM4cX8jNhnj1mtILXn1ugbfxc0tTDKtA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.0.tgz",
+      "integrity": "sha512-J/hvA+GJnuWJ0Sj8Z0dmu3JgMNU+MmusvkCT7+SN4/2TklW18FNCp/UuHIEhPZwHfy4sXfKYgC7kypKg4umbOw==",
       "requires": {
         "deep-equal": "~1.1.1",
         "defined": "~1.0.0",
+        "dotignore": "~0.1.2",
         "for-each": "~0.3.3",
         "function-bind": "~1.1.1",
         "glob": "~7.1.6",
@@ -8191,10 +8179,20 @@
         "is-regex": "~1.0.5",
         "minimist": "~1.2.0",
         "object-inspect": "~1.7.0",
-        "resolve": "~1.14.1",
+        "resolve": "~1.14.2",
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.2.1",
         "through": "~2.3.8"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
+          "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "tar": {
@@ -8400,15 +8398,15 @@
       "dev": true
     },
     "trim-trailing-lines": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
-      "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
       "dev": true
     },
     "trough": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
-      "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "changelog-version": "^1.0.1",
-    "common-good": "^1.1.18",
+    "common-good": "^1.1.19",
     "husky": "^3.0.5",
     "mkdirp": "^0.5.1",
     "nodemon": "^2.0.2",


### PR DESCRIPTION
Problem: CG's dependency, CSpell, had problems with Windows support, so
I was using a forked module as an alias to circumvent the problem. This
only works on very recent version of npm.

Solution: This morning the CSpell maintainer resolved the problem, so
the latest CG doesn't have to depend on an alias. This commit runs `npm
update` to get the latest version of CG so we don't have this problem.

Resolves #80 