### PR TITLE
Fix tangle bug when Patchwork is used as a server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
       "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.8.3"
       }
@@ -127,6 +128,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
       "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -272,6 +274,19 @@
         "ssb-tangle": "^1.0.1",
         "ssb-unix-socket": "^1.0.0",
         "ssb-ws": "^6.2.3"
+      },
+      "dependencies": {
+        "ssb-tangle": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ssb-tangle/-/ssb-tangle-1.0.1.tgz",
+          "integrity": "sha512-Miu42xjISxwQGX1J59VC1FgMmLQShILZeYXOhCL5aavoYm7nzeykrEM//pU55pVlUTAbXLttvhH56IDXTPX/Kw==",
+          "requires": {
+            "is-my-json-valid": "^2.20.0",
+            "pull-stream": "^3.6.11",
+            "ssb-ref": "^2.13.9",
+            "ssb-sort": "^1.1.3"
+          }
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -501,6 +516,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -906,6 +922,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -3202,7 +3219,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-network2": {
       "version": "0.0.1",
@@ -3850,7 +3868,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -5479,7 +5498,8 @@
     "picomatch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -8107,6 +8127,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ssb-mentions": "^0.5.0",
     "ssb-msgs": "^5.2.0",
     "ssb-ref": "^2.13.9",
+    "ssb-tangle": "^1.0.1",
     "ssb-thread-schema": "^1.1.1",
     "yargs": "^15.0.0"
   },

--- a/src/ssb.js
+++ b/src/ssb.js
@@ -59,12 +59,14 @@ const rawConnect = () =>
         if (err) {
           reject(err);
         } else {
-          // HACK: SSB-Tangle isn't available in Patchwork, but we want that
-          // compatibility. This code automatically injects SSB-Tangle into our
-          // stack so that we don't get weird errors when using Patchwork.
-          //
-          // See: https://github.com/fraction/oasis/issues/21
-          api.tangle = ssbTangle.init(api);
+          if (api.tangle === undefined) {
+            // HACK: SSB-Tangle isn't available in Patchwork, but we want that
+            // compatibility. This code automatically injects SSB-Tangle into our
+            // stack so that we don't get weird errors when using Patchwork.
+            //
+            // See: https://github.com/fraction/oasis/issues/21
+            api.tangle = ssbTangle.init(api);
+          }
 
           resolve(api);
         }

--- a/src/ssb.js
+++ b/src/ssb.js
@@ -8,6 +8,7 @@
 const ssbClient = require("ssb-client");
 const ssbConfig = require("ssb-config");
 const flotilla = require("@fraction/flotilla");
+const ssbTangle = require("ssb-tangle");
 const debug = require("debug")("oasis");
 
 const server = flotilla(ssbConfig);
@@ -58,6 +59,13 @@ const rawConnect = () =>
         if (err) {
           reject(err);
         } else {
+          // HACK: SSB-Tangle isn't available in Patchwork, but we want that
+          // compatibility. This code automatically injects SSB-Tangle into our
+          // stack so that we don't get weird errors when using Patchwork.
+          //
+          // See: https://github.com/fraction/oasis/issues/21
+          api.tangle = ssbTangle.init(api);
+
           resolve(api);
         }
       }


### PR DESCRIPTION
Problem: Patchwork is missing a plugin that we need to set the `branch`
property when posting a message. This property is important because it
helps us sort threads, so we're throwing an error when it isn't
available. See: https://github.com/fraction/oasis/issues/21

Solution: HACK THE ~~PLANET~~ API. This commit injects the plugin we
need via Oasis, which is a bit of a duct tape solution but it *is* a
solution.