### PR TITLE
Add simple nav sidebar on large screens

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -456,3 +456,24 @@ input[type="search"] {
 hr {
   border: var(--pico) solid var(--fg-alt);
 }
+
+/* sidebar only appears on big screens */
+@media (min-width: calc(45rem)) {
+  body > nav > ul {
+    justify-content: right;
+    flex-direction: column;
+    margin-right: var(--kilo);
+    position: sticky;
+    top: var(--whole);
+  }
+  body > nav > ul > li {
+    margin-bottom: var(--whole);
+  }
+  main {
+    max-width: var(--measure);
+  }
+  body {
+    display: flex;
+    justify-content: center;
+  }
+}

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -67,6 +67,7 @@ html {
   line-height: 1.5;
   margin: 0;
   padding: 0;
+  overflow-y: scroll;
 }
 
 main {

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -315,6 +315,8 @@ section {
   margin: var(--whole) 0;
   word-wrap: break-word;
   background: var(--bg);
+  width: 100%;
+  box-sizing: border-box;
 }
 
 section > header {
@@ -470,10 +472,12 @@ hr {
     margin-bottom: var(--whole);
   }
   main {
+    width: 100%;
     max-width: var(--measure);
   }
   body {
     display: flex;
     justify-content: center;
+    max-width: none;
   }
 }


### PR DESCRIPTION
Problem: Putting the navigation at the top of the screen makes it
impossible to use when you're scrolling through a page, which isn't a
good user experience. It was never meant to be permanent, and I think
everyone has pointed out that it's been a pain. See #28.

Solution: Super simple sidebar nav when people are on bigger screens.
This doesn't solve the problem on mobile, and it doesn't incorporate the
'popular' page's interval settings, but I think it's a step in the right
direction.