### PR TITLE
Use capitalization for Oasis links and buttons

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -46,6 +46,7 @@
   --common-radius: var(--micro);
   --measure: calc(var(--peta) + var(--mega));
   --line: 1.5rem;
+  --code-size: 85%;
 }
 
 * {
@@ -194,7 +195,7 @@ section code {
   overflow-wrap: break-word;
   padding: 0.125em 0.25em;
   margin: 0;
-  font-size: 85%;
+  font-size: var(--code-size);
   background-color: var(--bg);
   border-radius: var(--common-radius);
   border: var(--pico) solid var(--bg-status);

--- a/src/index.js
+++ b/src/index.js
@@ -99,15 +99,17 @@ router
     const publicPopular = async ({ period }) => {
       const messages = await post.popular({ period });
 
-      const option = somePeriod =>
-        li(
-          period === somePeriod
-            ? a({ class: "current", href: `./${somePeriod}` }, somePeriod)
-            : a({ href: `./${somePeriod}` }, somePeriod)
+      const option = somePeriod => {
+        const lowerPeriod = somePeriod.toLowerCase();
+        return li(
+          period === lowerPeriod
+            ? a({ class: "current", href: `./${lowerPeriod}` }, somePeriod)
+            : a({ href: `./${lowerPeriod}` }, somePeriod)
         );
+      };
 
       const prefix = nav(
-        ul(option("day"), option("week"), option("month"), option("year"))
+        ul(option("Day"), option("Week"), option("Month"), option("Year"))
       );
 
       return publicView({

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -162,14 +162,15 @@ module.exports = cooler => {
         dest: feedId
       });
 
+      // TODO: Refactor to stop doing awful string comparison.
       if (isFollowing === true && isBlocking === false) {
-        return "you are following";
+        return "You are following";
       } else if (isFollowing === false && isBlocking === true) {
-        return "you are blocking";
+        return "You are blocking";
       } else if (isFollowing === false && isBlocking === false) {
-        return "you are not following or blocking";
+        return "You are not following or blocking";
       } else {
-        return "you are following and blocking (!)";
+        return "You are following and blocking (!)";
       }
     }
   };

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -46,9 +46,9 @@ exports.authorView = ({
   const mention = `[@${name}](${feedId})`;
   const markdownMention = highlightJs.highlight("markdown", mention).value;
 
-  const areFollowing = relationship === "you are following";
+  const areFollowing = relationship === "You are following";
 
-  const contactFormType = areFollowing ? "unfollow" : "follow";
+  const contactFormType = areFollowing ? "Unfollow" : "Follow";
 
   // We're on our own profile!
   const contactForm =
@@ -82,7 +82,7 @@ exports.authorView = ({
       ? article({ innerHTML: description })
       : null,
     footer(
-      a({ href: `/likes/${encodeURIComponent(feedId)}` }, "view likes"),
+      a({ href: `/likes/${encodeURIComponent(feedId)}` }, "View likes"),
       span(relationship),
       contactForm
     )
@@ -150,7 +150,7 @@ exports.commentView = async ({ messages, myFeedId, parentMessage }) => {
         {
           type: "submit"
         },
-        "comment"
+        "Comment"
       )
     )
   );
@@ -239,7 +239,7 @@ exports.metaView = ({ status, peers, theme, themeNames }) => {
       form(
         { action: "/theme.css", method: "post" },
         select({ name: "theme" }, ...themeElements),
-        button({ type: "submit" }, "set theme")
+        button({ type: "submit" }, "Set theme")
       ),
       base16Elements,
       h2("Status"),
@@ -276,7 +276,7 @@ exports.publicView = ({ messages, prefix = null }) => {
           ". Messages cannot be edited or deleted."
         ),
         textarea({ required: true, name: "text" }),
-        button({ type: "submit" }, "submit")
+        button({ type: "submit" }, "Submit")
       )
     ),
     messages.map(msg => post({ msg }))
@@ -330,7 +330,7 @@ exports.replyView = async ({ messages, myFeedId }) => {
         {
           type: "submit"
         },
-        "reply"
+        "Reply"
       )
     )
   );
@@ -351,7 +351,7 @@ exports.searchView = ({ messages, query }) =>
           {
             type: "submit"
           },
-          "submit"
+          "Submit"
         )
       )
     ),

--- a/src/views/post.js
+++ b/src/views/post.js
@@ -152,9 +152,9 @@ module.exports = ({ msg }) => {
           `❤ ${likeCount}`
         )
       ),
-      a({ href: url.comment }, "comment"),
-      isPrivate || isRoot || isFork ? null : a({ href: url.reply }, "reply"),
-      a({ href: url.json }, "json")
+      a({ href: url.comment }, "Comment"),
+      isPrivate || isRoot || isFork ? null : a({ href: url.reply }, "Reply"),
+      a({ href: url.json }, "JSON")
     )
   );
 

--- a/src/views/template.js
+++ b/src/views/template.js
@@ -43,13 +43,13 @@ module.exports = (...elements) => {
     body(
       nav(
         ul(
-          li(a({ href: "/" }, "popular")),
-          li(a({ href: "/public/latest" }, "latest")),
-          li(a({ href: "/inbox" }, "inbox")),
-          li(a({ href: "/mentions" }, "mentions")),
-          li(a({ href: "/profile" }, "profile")),
-          li(a({ href: "/search" }, "search")),
-          li(a({ href: "/meta" }, "meta"))
+          li(a({ href: "/" }, "Popular")),
+          li(a({ href: "/public/latest" }, "Latest")),
+          li(a({ href: "/inbox" }, "Inbox")),
+          li(a({ href: "/mentions" }, "Mentions")),
+          li(a({ href: "/profile" }, "Profile")),
+          li(a({ href: "/search" }, "Search")),
+          li(a({ href: "/meta" }, "Meta"))
         )
       ),
       main({ id: "content" }, elements)


### PR DESCRIPTION
Problem: Using all-lowercase-everything isn't really a standard around
the web and it might be better to use consistent capitalization. This
was brought up in: https://github.com/fraction/oasis/issues/98

Solution: This changes the main navigation to use links with the first
letter capitalized, like how Patchwork + Twitter + Mastodon + etc do it.
This means that we're consistently using sentence case everywhere, which
I think is our best option. Originally I tried experimenting with
all-caps for actions, which I found aesthetically pleasing, but you have
to reduce the font size to make it look good (bad!) and I was reading
that all-caps text is harder for friends with dyslexia or vision
impairments.