### PR TITLE
Remove inline CSS to tighten CSP

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -456,3 +456,58 @@ input[type="search"] {
 hr {
   border: var(--pico) solid var(--fg-alt);
 }
+
+/* show off each theme color as a background */
+
+.theme-demo {
+  /* 100 / 15 because we don't demo the background */
+  width: 6.66%;
+  height: 1rem;
+  margin-top: 1em;
+  display: inline-block;
+}
+.theme-demo-01 {
+  background: var(--base01);
+}
+.theme-demo-02 {
+  background: var(--base02);
+}
+.theme-demo-03 {
+  background: var(--base03);
+}
+.theme-demo-04 {
+  background: var(--base04);
+}
+.theme-demo-05 {
+  background: var(--base05);
+}
+.theme-demo-06 {
+  background: var(--base06);
+}
+.theme-demo-07 {
+  background: var(--base07);
+}
+.theme-demo-08 {
+  background: var(--base08);
+}
+.theme-demo-09 {
+  background: var(--base09);
+}
+.theme-demo-0A {
+  background: var(--base0A);
+}
+.theme-demo-0B {
+  background: var(--base0B);
+}
+.theme-demo-0C {
+  background: var(--base0C);
+}
+.theme-demo-0D {
+  background: var(--base0D);
+}
+.theme-demo-0E {
+  background: var(--base0E);
+}
+.theme-demo-0F {
+  background: var(--base0F);
+}

--- a/src/http.js
+++ b/src/http.js
@@ -31,7 +31,7 @@ module.exports = ({ host, port, routes }) => {
       "img-src 'self'",
       "form-action 'self'",
       "media-src 'self'",
-      "style-src 'self' 'unsafe-inline'"
+      "style-src 'self'"
     ].join("; ");
 
     // Disallow scripts.

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -212,15 +212,7 @@ exports.metaView = ({ status, peers, theme, themeNames }) => {
   ];
 
   const base16Elements = base16.map(base =>
-    div({
-      style: {
-        "background-color": `var(--base${base})`,
-        width: `${(1 / base16.length) * 100}%`,
-        height: "1em",
-        "margin-top": "1em",
-        display: "inline-block"
-      }
-    })
+    div({ class: `theme-demo theme-demo-${base}` })
   );
 
   return template(


### PR DESCRIPTION
Problem: We were using inline CSS to show off the theme on the 'meta'
page, which meant that we couldn't tighten the CSP. This meant that
if you could figure out a CSS injection you'd be able to change how
Oasis looks, which could probably be malicious.

Solution: Add the CSS to `style.css` and remove that attack surface
area. Removing this inline CSS is a best practice, and while I don't
think a CSS injection is a super realistic threat there's no reason to
leave open holes in our CSP.