### PR TITLE
Hide private messages from author profiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -936,6 +936,7 @@
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2864,6 +2865,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ router
       const description = await about.description(feedId);
       const name = await about.name(feedId);
       const image = await about.image(feedId);
-      const messages = await post.fromFeed(feedId);
+      const messages = await post.fromPublicFeed(feedId);
       const relationship = await friend.getRelationship(feedId);
 
       const avatarUrl = `/image/256/${encodeURIComponent(image)}`;
@@ -195,7 +195,7 @@ router
       const name = await about.name(myFeedId);
       const image = await about.image(myFeedId);
 
-      const messages = await post.fromFeed(myFeedId);
+      const messages = await post.fromPublicFeed(myFeedId);
 
       const avatarUrl = `/image/256/${encodeURIComponent(image)}`;
 

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -435,7 +435,7 @@ module.exports = cooler => {
     );
 
   const post = {
-    fromFeed: async (feedId, customOptions = {}) => {
+    fromPublicFeed: async (feedId, customOptions = {}) => {
       const ssb = await cooler.connect();
 
       const myFeedId = ssb.id;
@@ -448,7 +448,7 @@ module.exports = cooler => {
           source,
           pull.filter(
             msg =>
-              typeof msg.value.content !== "string" &&
+              lodash.get(msg, "value.meta.private", false) === false &&
               msg.value.content.type === "post"
           ),
           pull.take(maxMessages),


### PR DESCRIPTION
Problem: Showing private posts on profiles is scary and may give people
the impression that these posts are visible.
https://github.com/fraction/oasis/issues/113

Solution: Hide private messages when rendering public profiles and
change the method name to be very clear that it only returns public
messages.