### PR TITLE
Replace "must" with "shall" in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ C4 provides a standard process for contributing, evaluating and discussing impro
 
 ## Language
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
 ## 1. Goals
 
@@ -42,22 +42,22 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 
 ### 2.1. Preliminaries
 
-1. The project SHALL use the git distributed revision control system.
-1. The project SHALL be hosted on github.com or equivalent, herein called the "Platform".
-1. The project SHALL use the Platform issue tracker.
+1. The project MUST use the git distributed revision control system.
+1. The project MUST be hosted on github.com or equivalent, herein called the "Platform".
+1. The project MUST use the Platform issue tracker.
 1. The project SHOULD have clearly documented guidelines for code style.
 1. A "Contributor" is a person who wishes to provide a patch, being a set of commits that solve some clearly identified problem.
 1. A "Maintainer" is a person who merges patches to the project. Maintainers are not developers; their job is to enforce process.
-1. Contributors SHALL NOT have commit access to the repository unless they are also Maintainers.
-1. Maintainers SHALL have commit access to the repository.
-1. Everyone, without distinction or discrimination, SHALL have an equal right to become a Contributor under the terms of this contract.
+1. Contributors MUST NOT have commit access to the repository unless they are also Maintainers.
+1. Maintainers MUST have commit access to the repository.
+1. Everyone, without distinction or discrimination, MUST have an equal right to become a Contributor under the terms of this contract.
 
 ### 2.2. Licensing and Ownership
 
-1. The project SHALL use a share-alike license such as the MPLv2, or a GPLv3 variant thereof (GPL, LGPL, AGPL).
-1. All contributions to the project source code ("patches") SHALL use the same license as the project.
-1. All patches are owned by their authors. There SHALL NOT be any copyright assignment process.
-1. Each Contributor SHALL be responsible for identifying themselves in the project Contributor list.
+1. The project MUST use a share-alike license such as the MPLv2, or a GPLv3 variant thereof (GPL, LGPL, AGPL).
+1. All contributions to the project source code ("patches") MUST use the same license as the project.
+1. All patches are owned by their authors. There MUST NOT be any copyright assignment process.
+1. Each Contributor MUST be responsible for identifying themselves in the project Contributor list.
 
 ### 2.3. Patch Requirements
 
@@ -65,28 +65,28 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 1. A patch SHOULD be a minimal and accurate answer to exactly one identified and agreed problem.
 1. A patch MUST adhere to the code style guidelines of the project if these are defined.
 1. A patch MUST adhere to the "Evolution of Public Contracts" guidelines defined below.
-1. A patch SHALL NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
+1. A patch MUST NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
 1. A patch MUST compile cleanly and pass project self-tests on at least the principal target platform.
 1. A patch commit message SHOULD consist of a single short (less than 50 characters) line stating the problem ("Problem: ...") being solved, followed by a blank line and then the proposed solution ("Solution: ...").
 1. A "Correct Patch" is one that satisfies the above requirements.
 
 ### 2.4. Development Process
 
-1. Change on the project SHALL be governed by the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.
+1. Change on the project MUST be governed by the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.
 1. To request changes, a user SHOULD log an issue on the project Platform issue tracker.
 1. The user or Contributor SHOULD write the issue by describing the problem they face or observe.
 1. The user or Contributor SHOULD seek consensus on the accuracy of their observation, and the value of solving the problem.
-1. Users SHALL NOT log feature requests, ideas, suggestions, or any solutions to problems that are not explicitly documented and provable.
-1. Thus, the release history of the project SHALL be a list of meaningful issues logged and solved.
-1. To work on an issue, a Contributor SHALL fork the project repository and then work on their forked repository.
-1. To submit a patch, a Contributor SHALL create a Platform pull request back to the project.
-1. A Contributor SHALL NOT commit changes directly to the project.
+1. Users MUST NOT log feature requests, ideas, suggestions, or any solutions to problems that are not explicitly documented and provable.
+1. Thus, the release history of the project MUST be a list of meaningful issues logged and solved.
+1. To work on an issue, a Contributor MUST fork the project repository and then work on their forked repository.
+1. To submit a patch, a Contributor MUST create a Platform pull request back to the project.
+1. A Contributor MUST NOT commit changes directly to the project.
 1. If the Platform implements pull requests as issues, a Contributor MAY directly send a pull request without logging a separate issue.
 1. To discuss a patch, people MAY comment on the Platform pull request, on the commit, or elsewhere.
-1. To accept or reject a patch, a Maintainer SHALL use the Platform interface.
+1. To accept or reject a patch, a Maintainer MUST use the Platform interface.
 1. Maintainers SHOULD NOT merge their own patches except in exceptional cases, such as non-responsiveness from other Maintainers for an extended period (more than 1-2 days).
-1. Maintainers SHALL NOT make value judgments on correct patches.
-1. Maintainers SHALL merge correct patches from other Contributors rapidly.
+1. Maintainers MUST NOT make value judgments on correct patches.
+1. Maintainers MUST merge correct patches from other Contributors rapidly.
 1. Maintainers MAY merge incorrect patches from other Contributors with the goals of (a) ending fruitless discussions, (b) capturing toxic patches in the historical record, (c) engaging with the Contributor on improving their patch quality.
 1. The user who created an issue SHOULD close the issue after checking the patch is successful.
 1. Any Contributor who has value judgments on a patch SHOULD express these via their own patches.
@@ -94,25 +94,25 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 
 ### 2.5. Branches and Releases
 
-1. The project SHALL have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
-1. The project SHALL NOT use topic branches for any reason. Personal forks MAY use topic branches.
-1. To make a stable release a Maintainer shall tag the repository. Stable releases SHALL always be released from the repository master.
+1. The project MUST have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
+1. The project MUST NOT use topic branches for any reason. Personal forks MAY use topic branches.
+1. To make a stable release a Maintainer must tag the repository. Stable releases MUST always be released from the repository master.
 
 ### 2.6. Evolution of Public Contracts
 
-1. All Public Contracts (APIs or protocols) SHALL be documented.
+1. All Public Contracts (APIs or protocols) MUST be documented.
 1. All Public Contracts SHOULD have space for extensibility and experimentation.
 1. A patch that modifies a stable Public Contract SHOULD not break existing applications unless there is overriding consensus on the value of doing this.
 1. A patch that introduces new features SHOULD do so using new names (a new contract).
 1. New contracts SHOULD be marked as "draft" until they are stable and used by real users.
 1. Old contracts SHOULD be deprecated in a systematic fashion by marking them as "deprecated" and replacing them with new contracts as needed.
 1. When sufficient time has passed, old deprecated contracts SHOULD be removed.
-1. Old names SHALL NOT be reused by new contracts.
+1. Old names MUST NOT be reused by new contracts.
 
 ### 2.7. Project Administration
 
-1. The project founders SHALL act as Administrators to manage the set of project Maintainers.
-1. The Administrators SHALL ensure their own succession over time by promoting the most effective Maintainers.
+1. The project founders MUST act as Administrators to manage the set of project Maintainers.
+1. The Administrators MUST ensure their own succession over time by promoting the most effective Maintainers.
 1. A new Contributor who makes correct patches, who clearly understands the project goals, and the process SHOULD be invited to become a Maintainer.
 1. Administrators SHOULD remove Maintainers who are inactive for an extended period of time, or who repeatedly fail to apply this process accurately.
 1. Administrators SHOULD block or ban "bad actors" who cause stress and pain to others in the project. This should be done after public discussion, with a chance for all parties to speak. A bad actor is someone who repeatedly ignores the rules and culture of the project, who is needlessly argumentative or hostile, or who is offensive, and who is unable to self-correct their behavior when asked to do so by others.


### PR DESCRIPTION
Problem: The word "shall" is ambiguous and seems pretentious rather than
friendly. More info here: https://www.plainlanguage.gov/guidelines/conversational/shall-and-must/

Solution: Replace "shall" with "must". It has the same semantics with
none of the ambiguity or cultural baggage.