### PR TITLE
Make 'Popular' page faster

### DIFF
--- a/src/models/index.js
+++ b/src/models/index.js
@@ -685,11 +685,11 @@ module.exports = cooler => {
           source,
           pull.filter(msg => {
             return (
+              msg.value.timestamp > earliest &&
               typeof msg.value.content === "object" &&
               typeof msg.value.content.vote === "object" &&
               typeof msg.value.content.vote.link === "string" &&
-              typeof msg.value.content.vote.value === "number" &&
-              msg.value.timestamp > earliest
+              typeof msg.value.content.vote.value === "number"
             );
           }),
           pull.reduce(


### PR DESCRIPTION
Problem: The popular page is ungodly slow.

Solution: Make it faster! This is done by checking the timestamp before
the other constraints that we add to messages, which is mostly useful
because most messages that fail the filter will fail on the timestamp
check.

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `curl http://localhost:4515/public/popular/year` | 13.159 ± 0.480 | 12.843 | 14.450 | 1.21 ± 0.05 |
| `curl http://localhost:3000/public/popular/year` | 10.866 ± 0.163 | 10.594 | 11.133 | 1.00 |
