### PR TITLE
Add basic following page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,11 @@ router
     };
     ctx.body = await publicLatest();
   })
+  .get("/public/latest/following", async ctx => {
+    const messages = await post.latestFollowing();
+
+    ctx.body = await publicView({ messages });
+  })
   .get("/author/:feed", async ctx => {
     const { feed } = ctx.params;
     const author = async feedId => {

--- a/src/views/template.js
+++ b/src/views/template.js
@@ -45,6 +45,7 @@ module.exports = (...elements) => {
         ul(
           li(a({ href: "/" }, "Popular")),
           li(a({ href: "/public/latest" }, "Latest")),
+          li(a({ href: "/public/latest/following" }, "Following")),
           li(a({ href: "/inbox" }, "Inbox")),
           li(a({ href: "/mentions" }, "Mentions")),
           li(a({ href: "/profile" }, "Profile")),


### PR DESCRIPTION
Problem: We don't always want to see all of the messages on our
computer, sometimes we just want to see messages from the people we're
explicitly following. The 'Popular' and 'Latest' pages don't help with
that. See #57 

Solution: Add a super basic page that just shows the latest messages
from the people you're explicitly following.