### PR TITLE
Specify exact Node.js engine support and test it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 # Use Node.js configuration.
 language: node_js
 
-# Both latest Node.js and latest LTS.
+# Test the latest and LTS releases >= LTS Dubnium (10).
 node_js:
-  - lts/*
+  - lts/dubnium
+  - lts/erbium
   - node
 
 # All of the operating systems!
-# Note: Windows support is very iffy.
+# Note: Windows support is iffy.
 os:
   - linux
   - osx

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
   "directories": {
     "doc": "docs"
   },
-  "keywords": []
+  "keywords": [],
+  "engines": {
+    "node": "^10.0.0 || >=12.0.0"
+  }
 }


### PR DESCRIPTION
Problem: Targeting only the latest version of Node.js and the latest LTS
means that we have a sort of rolling backward-compatibility that's hard
to reason about. If we break compatibility, we should release those
changes as a major version, but the current strategy makes it difficult
to tell exactly when we're breaking compatibility.

Solution: Specify the exact Node.js versions that we want to support in
`package.json` and add the specific tests to `.travis.yml`. In the
future we can break compatibility if it's helpful but we'll have to do
so explicitly and release the change as a major version.

**What's the problem you solved?**

**What solution are you recommending?**
