### PR TITLE
Update Flotilla to drop SSB-Links2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -183,9 +183,9 @@
       "integrity": "sha512-Lnle0J8t+Z+jFg78GFFnGo+Fphxaco9K9SppeBDsI27QBRBumxeGAMeOg5wt6XbAuj5pQWmAEWWEwPz4PYGMHw=="
     },
     "@fraction/flotilla": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@fraction/flotilla/-/flotilla-3.0.2.tgz",
-      "integrity": "sha512-Saq4sZdp0ANkqACCF2tfheJbFm4tjKOJnkeM9iZiMzVDp9GQCmSSy3ZE+ffljcVFrWGMwZSc8kvEKa+UzIC4xQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@fraction/flotilla/-/flotilla-4.0.0.tgz",
+      "integrity": "sha512-n1CmZff4MfXexv6eX8HLojLBrVZa3zpkEndwtRYpjJMZIZPmX9belPFCeutzMupEY7D/0we2gsJ6C030h63zYA==",
       "requires": {
         "lodash.shuffle": "^4.2.0",
         "secret-stack": "^6.3.0",
@@ -198,7 +198,6 @@
         "ssb-friends": "^4.1.4",
         "ssb-invite": "^2.1.3",
         "ssb-lan": "^0.2.0",
-        "ssb-links": "^3.0.8",
         "ssb-logging": "^1.0.0",
         "ssb-master": "^1.0.3",
         "ssb-no-auth": "^1.0.0",
@@ -212,19 +211,6 @@
         "ssb-tangle": "^1.0.1",
         "ssb-unix-socket": "^1.0.0",
         "ssb-ws": "^6.2.3"
-      },
-      "dependencies": {
-        "ssb-tangle": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ssb-tangle/-/ssb-tangle-1.0.1.tgz",
-          "integrity": "sha512-Miu42xjISxwQGX1J59VC1FgMmLQShILZeYXOhCL5aavoYm7nzeykrEM//pU55pVlUTAbXLttvhH56IDXTPX/Kw==",
-          "requires": {
-            "is-my-json-valid": "^2.20.0",
-            "pull-stream": "^3.6.11",
-            "ssb-ref": "^2.13.9",
-            "ssb-sort": "^1.1.3"
-          }
-        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -936,7 +922,6 @@
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2297,17 +2282,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "semver": {
           "version": "6.3.0",
@@ -2865,13 +2840,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -5668,25 +5636,6 @@
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0",
         "which-pm-runs": "^1.0.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "optional": true
-            }
-          }
-        }
       }
     },
     "prelude-ls": {
@@ -7248,14 +7197,6 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "requires": {
-            "minimist": "0.0.8"
-          }
         }
       }
     },
@@ -7270,29 +7211,6 @@
         "secret-stack-decorators": "~1.0.0",
         "ssb-keys": "^7.2.0",
         "ssb-ref": "^2.13.9"
-      }
-    },
-    "ssb-links": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/ssb-links/-/ssb-links-3.0.8.tgz",
-      "integrity": "sha512-7b1PGn9Pmaf5FfW0xDNc+4w2uOR7JwIJSsbKA/DDP0ejMzBlc9H38iVaMrf4927X5Cdn73o82D6cv8vXGqC4AQ==",
-      "requires": {
-        "flumeview-query": "^6.0.0",
-        "map-filter-reduce": "^2.0.0",
-        "ssb-msgs": "^5.2.0"
-      },
-      "dependencies": {
-        "map-filter-reduce": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-2.2.1.tgz",
-          "integrity": "sha1-YysSfDrl1q2eIc/dlpG2O4lE/NI=",
-          "requires": {
-            "binary-search": "^1.2.0",
-            "pull-sink-through": "0.0.0",
-            "pull-stream": "^3.3.0",
-            "typewiselite": "^1.0.0"
-          }
-        }
       }
     },
     "ssb-logging": {
@@ -8140,17 +8058,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -8169,17 +8077,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -8920,17 +8818,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@fraction/base16-css": "^1.1.0",
-    "@fraction/flotilla": "^3.0.2",
+    "@fraction/flotilla": "^4.0.0",
     "debug": "^4.1.1",
     "highlight.js": "^9.18.0",
     "hyperaxe": "^1.3.0",


### PR DESCRIPTION
Problem: We aren't using the index at all so Oasis is just wasting time
and CPU power.

Solution: Upgrade Flotilla and resolve the problem.