### PR TITLE
Fix SVG rendering by setting content-type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3201,6 +3201,11 @@
       "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
+    "html-comment-regex": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+      "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
+    },
     "html-element": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.0.tgz",
@@ -3731,6 +3736,14 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-svg": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-4.2.1.tgz",
+      "integrity": "sha512-PHx3ANecKsKNl5y5+Jvt53Y4J7MfMpbNZkv384QNiswMKAWIbvcqbPz+sYbFKJI8Xv3be01GSFniPmoaP+Ai5A==",
+      "requires": {
+        "html-comment-regex": "^1.1.2"
+      }
     },
     "is-symbol": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "debug": "^4.1.1",
     "highlight.js": "^9.18.0",
     "hyperaxe": "^1.3.0",
+    "is-svg": "^4.2.1",
     "koa": "^2.7.0",
     "koa-body": "^4.1.0",
     "koa-mount": "^4.0.0",


### PR DESCRIPTION
Problem: Most browsers parse SVG files as XML and refuse to display it
in an `<img>` tag. It's usually unsafe to have browsers try to sniff the
file type themselves, because they can be tricked into running unsafe
code, so we want to set the file type ourselves in the server.

Solution: Use the Is-SVG library for a quick-n-dirty check for whether a
buffer is an SVG. If so, we set the file type accordingly.