### PR TITLE
Navbar refresh: reorder, rename, add emojis

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -392,13 +392,15 @@ label {
 
 nav > ul {
   display: flex;
-  justify-content: space-between;
+  flex-wrap: wrap;
+  justify-content: flex-start;
   margin: 0;
   padding: 0;
 }
 
 nav > ul > li {
   list-style: none;
+  margin-right: var(--milli);
 }
 
 .profile {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -247,7 +247,7 @@ exports.metaView = ({ status, peers, theme, themeNames }) => {
   return template(
     section(
       { class: "message" },
-      h1("Meta"),
+      h1("Settings"),
       p(
         "Check out ",
         a({ href: "/meta/readme" }, "the readme"),

--- a/src/views/template.js
+++ b/src/views/template.js
@@ -46,8 +46,8 @@ module.exports = (...elements) => {
           li(a({ href: "/" }, "📣 Popular")),
           li(a({ href: "/public/latest" }, "🆕 Latest")),
           li(a({ href: "/public/latest/following" }, "👭 Following")),
-          li(a({ href: "/mentions" }, "💬 Mentions")),
           li(a({ href: "/profile" }, "🐱 Profile")),
+          li(a({ href: "/mentions" }, "💬 Mentions")),
           li(a({ href: "/inbox" }, "✉️ Private")),
           li(a({ href: "/search" }, "🔍 Search")),
           li(a({ href: "/meta" }, "⚙ Settings"))

--- a/src/views/template.js
+++ b/src/views/template.js
@@ -44,7 +44,7 @@ module.exports = (...elements) => {
       nav(
         ul(
           li(a({ href: "/" }, "📣 Popular")),
-          li(a({ href: "/public/latest" }, "🆕 Latest")),
+          li(a({ href: "/public/latest" }, "🐇 Latest")),
           li(a({ href: "/public/latest/following" }, "👭 Following")),
           li(a({ href: "/profile" }, "🐱 Profile")),
           li(a({ href: "/mentions" }, "💬 Mentions")),

--- a/src/views/template.js
+++ b/src/views/template.js
@@ -43,14 +43,14 @@ module.exports = (...elements) => {
     body(
       nav(
         ul(
-          li(a({ href: "/" }, "Popular")),
-          li(a({ href: "/public/latest" }, "Latest")),
-          li(a({ href: "/public/latest/following" }, "Following")),
-          li(a({ href: "/inbox" }, "Inbox")),
-          li(a({ href: "/mentions" }, "Mentions")),
-          li(a({ href: "/profile" }, "Profile")),
-          li(a({ href: "/search" }, "Search")),
-          li(a({ href: "/meta" }, "Meta"))
+          li(a({ href: "/" }, "📣 Popular")),
+          li(a({ href: "/public/latest" }, "🆕 Latest")),
+          li(a({ href: "/public/latest/following" }, "👭 Following")),
+          li(a({ href: "/mentions" }, "💬 Mentions")),
+          li(a({ href: "/profile" }, "🐱 Profile")),
+          li(a({ href: "/inbox" }, "✉️ Private")),
+          li(a({ href: "/search" }, "🔍 Search")),
+          li(a({ href: "/meta" }, "⚙ Settings"))
         )
       ),
       main({ id: "content" }, elements)


### PR DESCRIPTION
**What's the problem you solved?**
In several issues we've discussed renaming pages in the navbar and changing their order.

**What solution are you recommending?**
This PR:
* Reorders the navbar links to follow the gradient of intimacy from public to private #57 #117
* Renames Inbox --> Private, and Meta --> Settings #116 to be more similar to Mastodon
* Adds emojis because there are now too many items in the navbar list to comprehend at a glance

![Screen Shot 2020-01-31 at 4 08 59 PM](https://user-images.githubusercontent.com/32660718/73582867-07f23480-4444-11ea-9aa8-d5f6798ed701.png)

I'm not sure the emojis are a good idea.  If we don't like them after a couple of days we can remove them in another commit.  This is an accidental stress-test for our C4 process :)

I'd prefer to have simpler monochrome icons that are less distracting.  It was a challenge to find sensical emojis for these concepts.  I was especially trying to avoid these ones: 👤 👥 🆕 📈 👪

Also I didn't change the URLs for the pages yet; I'm going to wait for the dust to settle on this PR first.