### PR TITLE
Remove follow button from your own profile

### DIFF
--- a/src/views/index.js
+++ b/src/views/index.js
@@ -50,9 +50,8 @@ exports.authorView = ({
 
   const contactFormType = areFollowing ? "Unfollow" : "Follow";
 
-  // We're on our own profile!
   const contactForm =
-    relationship !== null
+    relationship !== null && relationship !== "this is you"
       ? form(
           {
             action: `/${contactFormType}/${encodeURIComponent(feedId)}`,
@@ -65,7 +64,7 @@ exports.authorView = ({
             contactFormType
           )
         )
-      : null;
+      : null; // We're on our own profile!
 
   const prefix = section(
     { class: "message" },


### PR DESCRIPTION
The "Follow" button was showing on your own profile.

I took a screenshot an hour ago and it wasn't there, and then it was.  Was there a change to capitalize the relationship strings ("You are following" etc)?  It would be good to refactor these relationship strings into constants.