### PR TITLE
Fix help link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Want more? Check out [`install.md`](https://github.com/fraction/oasis/blob/maste
 
 - [Contributing](https://github.com/fraction/oasis/blob/master/docs/contributing.md)
 - [Architecture](https://github.com/fraction/oasis/blob/master/docs/architecture.md)
-- [Help](https://github.com/fraction/oasis/issues/new/choose)
+- [Help](https://github.com/fraction/oasis/issues/new)
 - [Roadmap](https://github.com/fraction/oasis/blob/master/docs/roadmap.md)
 - [Security Policy](https://github.com/fraction/oasis/blob/master/docs/security.md)
 - [Source Code](https://github.com/fraction/oasis.git)


### PR DESCRIPTION
Problem: Help link in readme was pointing to the issue type selection
which is no longer useful because we just have one template. Resolves #56 

Solution: Fix the link and point directly to the issue creation link.