### PR TITLE
Fix /image/ URL returning a broken image

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -17,6 +17,7 @@ module.exports = ({ host, port, routes }) => {
     // Output full error objects
     err.message = err.stack;
     err.expose = true;
+    console.error(err);
     return null;
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -269,11 +269,15 @@ router
   })
   .get("/image/:imageSize/:blobId", async ctx => {
     const { blobId, imageSize } = ctx.params;
-    ctx.type = "image/png";
+    if (sharp) {
+      ctx.type = "image/png";
+    }
+
     const fakePixel = Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
       "base64"
     );
+
     const fakeImage = imageSize =>
       sharp
         ? sharp({
@@ -289,7 +293,10 @@ router
               }
             }
           })
+            .png()
+            .toBuffer()
         : new Promise(resolve => resolve(fakePixel));
+
     const image = async ({ blobId, imageSize }) => {
       const bufferSource = await blob.get({ blobId });
       const fakeId = "&0000000000000000000000000000000000000000000=.sha256";


### PR DESCRIPTION
Problem: I think during a refactor this code was changed and ended up
breaking the "fake image" that we return when the user doesn't have an
image. We also don't see image errors because they aren't in the browser
viewport if they return text and we don't `console.error()` our errors.

Resolves #138?

Solution: Fix the image code to return a PNG as a buffer and duplicate
errors to stderr.