### PR TITLE
Fix nav alignment on smaller screens

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -393,7 +393,7 @@ label {
 nav > ul {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-start;
+  justify-content: space-around;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
Problem: The nav is aligned to the left of the screen on mobile, which
feels off-center and unbalanced on mobile. Resolves https://github.com/fraction/oasis/issues/135

Solution: Center the menu to optimize for space around the links.

![Screenshot_2020-02-02 Oasis(2)](https://user-images.githubusercontent.com/537700/73618286-7caba700-45db-11ea-8e8f-c2d75c74866a.png)
![Screenshot_2020-02-02 Oasis(1)](https://user-images.githubusercontent.com/537700/73618288-7caba700-45db-11ea-9ff9-89015a54f0d4.png)
![Screenshot_2020-02-02 Oasis](https://user-images.githubusercontent.com/537700/73618289-7caba700-45db-11ea-8fa4-ceed20f421fc.png)
