### PR TITLE
Add bleeding-edge install instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,19 @@ Options:
 
 ## Installation
 
-Most people should install Oasis with [npm](https://npmjs.org/).
+Most people should install stable releases with [npm](https://npmjs.org/).
 
 ```shell
 npm --global install @fraction/oasis@latest
 ```
 
 Please make sure that your Node.js version is the [**current** or **active LTS** release](https://nodejs.org/en/about/releases/).
+
+For faster updates and less stability, install from GitHub and upgrade often.
+
+```shell
+npm --global install github:fraction/oasis
+```
 
 Want more? Check out [`install.md`](https://github.com/fraction/oasis/blob/master/docs/install.md).
 


### PR DESCRIPTION
Problem: https://github.com/fraction/oasis/issues/149

Solution: Add note to the readme advertising the npm install straight
from GitHub, which will pull the latest `master`.
