### PR TITLE
Add invite code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -560,6 +560,11 @@ router
   .post("/meta/conn/restart", koaBody(), async ctx => {
     await meta.connRestart();
     ctx.redirect("/meta");
+  })
+  .post("/meta/invite/accept", koaBody(), async ctx => {
+    const invite = String(ctx.request.body.invite);
+    await meta.acceptInvite(invite);
+    ctx.redirect("/meta");
   });
 
 const { host } = config;

--- a/src/models.js
+++ b/src/models.js
@@ -193,6 +193,10 @@ module.exports = cooler => {
     connRestart: async () => {
       await models.meta.connStop();
       await models.meta.connStart();
+    },
+    acceptInvite: async invite => {
+      const ssb = await cooler.connect();
+      return await cooler.get(ssb.invite.accept, invite);
     }
   };
 

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -3,9 +3,9 @@ const { a, strong } = require("hyperaxe");
 module.exports = {
   en: {
     // navbar items
-    extended: "Extended",
     extendedDescription:
       "Who: People you're not following\nWhat: Posts and comments",
+    extended: "Extended",
     popular: "Popular",
     popularDescription:
       "Posts and comments (from anyone) with the most hearts (from people you follow)",
@@ -95,6 +95,10 @@ module.exports = {
     stopNetworking: "Stop networking",
     restartNetworking: "Restart networking",
     indexes: "Indexes",
+    invites: "Invites",
+    invitesDescription:
+      "Redeem an invite by pasting it below. If it works, you'll follow the feed and they'll follow you back.",
+    acceptInvite: "Accept invite",
     // search page
     searchLabel: "Add word(s) to look for in downloaded messages.",
     // posts and comments
@@ -109,8 +113,7 @@ module.exports = {
     mysteryDescription: "posted a mysterious message",
     // misc
     oasisDescription: "Friendly neighborhood scuttlebutt interface",
-    submit: "Submit",
-    following: "Following" // TODO: remove this - it isn't used now that the Following page is gone
+    submit: "Submit"
   },
   /* spell-checker: disable */
   es: {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -510,6 +510,13 @@ exports.metaView = ({ status, peers, theme, themeNames }) => {
       peerList.length > 0 ? ul(peerList) : i18n.noConnections,
       p(i18n.connectionActionIntro),
       connButtons,
+      h3(i18n.invites),
+      p(i18n.invitesDescription),
+      form(
+        { action: "/meta/invite/accept", method: "post" },
+        input({ name: "invite", type: "text" }),
+        button({ type: "submit" }, i18n.acceptInvite)
+      ),
       h3(i18n.indexes),
       progressElements
     )


### PR DESCRIPTION
Problem: There was no way to onboard new users since we couldn't redeem
invites.

Solution: Add basic follow-back invites to the settings page. This takes
an invite string, runs it through invite.accept, and either returns the
error in full *or* redeems the invite quietly. Resolves #97 

---

Note: This branch contains commits from the other PRs for i18n and such. Once the other PRs are merged I'll squash this and mark it 'Ready for review'.