### PR TITLE
Add description of each feed at the top of the page

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -321,6 +321,11 @@ section {
   box-sizing: border-box;
 }
 
+.viewInfo {
+  background: none;
+  white-space: pre-line; /* preserve newlines */
+}
+
 section > header {
   height: var(--line);
   display: flex;

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ const {
   commentView,
   extendedView,
   latestView,
+  likesView,
   listView,
   markdownView,
   metaView,
@@ -360,10 +361,14 @@ router
   })
   .get("/likes/:feed", async ctx => {
     const { feed } = ctx.params;
-
     const likes = async ({ feed }) => {
-      const messages = await post.likes({ feed });
-      return listView({ messages });
+      const pendingMessages = post.likes({ feed });
+      const pendingName = about.name(feed);
+      return likesView({
+        messages: await pendingMessages,
+        feed,
+        name: await pendingName
+      });
     };
     ctx.body = await likes({ feed });
   })

--- a/src/index.js
+++ b/src/index.js
@@ -46,13 +46,16 @@ const { about, blob, friend, meta, post, vote } = require("./models")(cooler);
 const {
   authorView,
   commentView,
+  extendedView,
+  latestView,
   listView,
   markdownView,
   metaView,
-  publicView,
+  popularView,
   replyView,
   searchView,
-  setLanguage
+  setLanguage,
+  topicsView
 } = require("./views");
 
 let sharp;
@@ -114,7 +117,7 @@ router
         ul(option("Day"), option("Week"), option("Month"), option("Year"))
       );
 
-      return publicView({
+      return popularView({
         messages,
         prefix
       });
@@ -123,15 +126,15 @@ router
   })
   .get("/public/latest", async ctx => {
     const messages = await post.latest();
-    ctx.body = await publicView({ messages });
+    ctx.body = await latestView({ messages });
   })
   .get("/public/latest/extended", async ctx => {
     const messages = await post.latestExtended();
-    ctx.body = await publicView({ messages });
+    ctx.body = await extendedView({ messages });
   })
   .get("/public/latest/topics", async ctx => {
     const messages = await post.latestTopics();
-    ctx.body = await publicView({ messages });
+    ctx.body = await topicsView({ messages });
   })
   .get("/author/:feed", async ctx => {
     const { feed } = ctx.params;

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -33,6 +33,8 @@ module.exports = {
     relationshipConflict: "You are somehow both following and blocking",
     // author view
     viewLikes: "View likes",
+    // likes view
+    likedBy: "'s likes",
     // composer
     publish: "Publish",
     commentWarning: [

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -2,9 +2,28 @@ const { a, strong } = require("hyperaxe");
 
 module.exports = {
   en: {
+    // navbar items
+    extended: "Extended",
+    extendedDescription:
+      "Who: People you're not following\nWhat: Posts and comments",
+    popular: "Popular",
+    popularDescription:
+      "Posts and comments (from anyone) with the most hearts (from people you follow)",
+    latest: "Latest",
+    latestDescription: "Who: People you're following\nWhat: Posts and comments",
+    topics: "Topics",
+    topicsDescription:
+      "Who: People you're following\nWhat: Posts.  (To see comments, click the timestamp of a post)",
+    profile: "Profile",
+    mentions: "Mentions",
+    private: "Private",
+    search: "Search",
+    settings: "Settings",
+    // post actions
     comment: "Comment",
     reply: "Reply",
     json: "JSON",
+    // relationships
     unfollow: "Unfollow",
     follow: "Follow",
     relationshipFollowing: "You are following",
@@ -12,7 +31,10 @@ module.exports = {
     relationshipBlocking: "You are blocking",
     relationshipNone: "You are neither following or blocking",
     relationshipConflict: "You are somehow both following and blocking",
+    // author view
     viewLikes: "View likes",
+    // composer
+    publish: "Publish",
     commentWarning: [
       " Messages cannot be edited or deleted. To respond to an individual message, select ",
       strong("reply"),
@@ -25,28 +47,6 @@ module.exports = {
       a({ href: markdownUrl }, "Markdown"),
       "."
     ],
-    startNetworking: "Start networking",
-    stopNetworking: "Stop networking",
-    restartNetworking: "Restart networking",
-    settingsIntro: ({ readmeUrl }) => [
-      "Check out ",
-      a({ href: readmeUrl }, "the readme"),
-      ", configure your theme, or view debugging information below."
-    ],
-    theme: "Theme",
-    settings: "Settings",
-    themeIntro:
-      "Choose from any theme you'd like. The default theme is Atelier-SulphurPool-Light.",
-    setTheme: "Set theme",
-    status: "Status",
-    peerConnections: "Peer Connections 💻⚡️💻",
-    connectionsIntro:
-      "Your computer is syncing data with these other computers. It will connect to any scuttlebutt pub and peer it can find, even if you have no relationship with them, as it looks for data from your friends.",
-    noConnections: "No peers connected.",
-    connectionActionIntro:
-      "You can decide when you want your computer to network with peers. You can start, stop, or restart your networking whenever you'd like.",
-    indexes: "Indexes",
-    publish: "Publish",
     newMessageLabel: ({ markdownUrl, linkTarget }) => [
       "Write a new message in ",
       a(
@@ -58,7 +58,6 @@ module.exports = {
       ),
       ". Messages cannot be edited or deleted."
     ],
-    submit: "Submit",
     replyLabel: ({ markdownUrl }) => [
       "Write a ",
       strong("public reply"),
@@ -68,15 +67,35 @@ module.exports = {
       strong("comment"),
       " instead."
     ],
-    search: "Search",
+    // settings
+    settingsIntro: ({ readmeUrl }) => [
+      "Check out ",
+      a({ href: readmeUrl }, "the readme"),
+      ", configure your theme, or view debugging information below."
+    ],
+    theme: "Theme",
+    themeIntro:
+      "Choose from any theme you'd like. The default theme is Atelier-SulphurPool-Light.",
+    setTheme: "Set theme",
+    language: "Language",
+    languageDescription:
+      "If you'd like to use Oasis in another language, choose one below. Please be aware that this is very new and very basic. We'd love your help translating Oasis to other languages and locales.",
+    setLanguage: "Set language",
+
+    status: "Status",
+    peerConnections: "Peer Connections 💻⚡️💻",
+    connectionsIntro:
+      "Your computer is syncing data with these other computers. It will connect to any scuttlebutt pub and peer it can find, even if you have no relationship with them, as it looks for data from your friends.",
+    noConnections: "No peers connected.",
+    connectionActionIntro:
+      "You can decide when you want your computer to network with peers. You can start, stop, or restart your networking whenever you'd like.",
+    startNetworking: "Start networking",
+    stopNetworking: "Stop networking",
+    restartNetworking: "Restart networking",
+    indexes: "Indexes",
+    // search page
     searchLabel: "Add word(s) to look for in downloaded messages.",
-    oasisDescription: "Friendly neighborhood scuttlebutt interface",
-    popular: "Popular",
-    latest: "Latest",
-    following: "Following",
-    profile: "Profile",
-    mentions: "Mentions",
-    private: "Private",
+    // posts and comments
     commentDescription: ({ parentUrl }) => [
       "commented on ",
       a({ href: parentUrl }, " thread")
@@ -86,12 +105,10 @@ module.exports = {
       a({ href: parentUrl }, " message")
     ],
     mysteryDescription: "posted a mysterious message",
-    language: "Language",
-    languageDescription:
-      "If you'd like to use Oasis in another language, choose one below. Please be aware that this is very new and very basic. We'd love your help translating Oasis to other languages and locales.",
-    setLanguage: "Set language",
-    extended: "Extended",
-    topics: "Topics"
+    // misc
+    oasisDescription: "Friendly neighborhood scuttlebutt interface",
+    submit: "Submit",
+    following: "Following" // TODO: remove this - it isn't used now that the Following page is gone
   },
   /* spell-checker: disable */
   es: {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -528,7 +528,6 @@ const viewInfoBox = ({ viewTitle = null, viewDescription = null }) => {
 };
 
 exports.likesView = async ({ messages, feed, name }) => {
-  console.log(feed);
   const authorLink = a(
     { href: `/author/${encodeURIComponent(feed)}` },
     "@" + name

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -11,6 +11,7 @@ const {
   button,
   details,
   div,
+  em,
   footer,
   form,
   h1,
@@ -515,10 +516,25 @@ exports.metaView = ({ status, peers, theme, themeNames }) => {
   );
 };
 
-exports.publicView = ({ messages, prefix = null }) => {
+exports.publicView = ({
+  messages,
+  prefix = null,
+  viewTitle = null,
+  viewDescription = null
+}) => {
   const publishForm = "/publish/";
 
+  let viewInfoBox = null;
+  if (viewTitle || viewDescription) {
+    viewInfoBox = section(
+      { class: "viewInfo" },
+      viewTitle ? h1(viewTitle) : null,
+      viewDescription ? em(viewDescription) : null
+    );
+  }
+
   return template(
+    viewInfoBox,
     prefix,
     section(
       header(strong(i18n.publish)),
@@ -534,6 +550,42 @@ exports.publicView = ({ messages, prefix = null }) => {
     ),
     messages.map(msg => post({ msg }))
   );
+};
+
+exports.popularView = ({ messages, prefix = null }) => {
+  return this.publicView({
+    messages,
+    prefix,
+    viewTitle: i18n.popular,
+    viewDescription: i18n.popularDescription
+  });
+};
+
+exports.extendedView = ({ messages, prefix = null }) => {
+  return this.publicView({
+    messages,
+    prefix,
+    viewTitle: i18n.extended,
+    viewDescription: i18n.extendedDescription
+  });
+};
+
+exports.latestView = ({ messages, prefix = null }) => {
+  return this.publicView({
+    messages,
+    prefix,
+    viewTitle: i18n.latest,
+    viewDescription: i18n.latestDescription
+  });
+};
+
+exports.topicsView = ({ messages, prefix = null }) => {
+  return this.publicView({
+    messages,
+    prefix,
+    viewTitle: i18n.topics,
+    viewDescription: i18n.topicsDescription
+  });
 };
 
 exports.replyView = async ({ messages, myFeedId }) => {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -516,6 +516,32 @@ exports.metaView = ({ status, peers, theme, themeNames }) => {
   );
 };
 
+const viewInfoBox = ({ viewTitle = null, viewDescription = null }) => {
+  if (!viewTitle && !viewDescription) {
+    return null;
+  }
+  return section(
+    { class: "viewInfo" },
+    viewTitle ? h1(viewTitle) : null,
+    viewDescription ? em(viewDescription) : null
+  );
+};
+
+exports.likesView = async ({ messages, feed, name }) => {
+  console.log(feed);
+  const authorLink = a(
+    { href: `/author/${encodeURIComponent(feed)}` },
+    "@" + name
+  );
+
+  return template(
+    viewInfoBox({
+      viewTitle: span(authorLink, i18n.likedBy)
+    }),
+    messages.map(msg => post({ msg }))
+  );
+};
+
 exports.publicView = ({
   messages,
   prefix = null,
@@ -524,17 +550,8 @@ exports.publicView = ({
 }) => {
   const publishForm = "/publish/";
 
-  let viewInfoBox = null;
-  if (viewTitle || viewDescription) {
-    viewInfoBox = section(
-      { class: "viewInfo" },
-      viewTitle ? h1(viewTitle) : null,
-      viewDescription ? em(viewDescription) : null
-    );
-  }
-
   return template(
-    viewInfoBox,
+    viewInfoBox({ viewTitle, viewDescription }),
     prefix,
     section(
       header(strong(i18n.publish)),


### PR DESCRIPTION
### Problem
We have a lot of feeds with short names (Topics, Extended...) but it's not clear what they really mean.

### Solution
This adds a title and descriptive text to most of the feeds:

![Screen Shot 2020-02-04 at 2 01 55 PM](https://user-images.githubusercontent.com/32660718/73791317-eef4c680-4756-11ea-912f-e380ef9bb564.png)

Added to:
* [x] Extended
* [x] Popular
* [x] Latest
* [x] Topics
* [x] An author's Likes page

Not changed
* Author profile page (it already has an info card about the author)
* Search (it already has the search box)

### Future work for another day

Add the remaining pages:
* [ ] Mentions
* [ ] Private

Other things
* [ ] Improve the CSS - I'm not especially happy with the layout and fonts
* [ ] I embedded `\n` into the i18n strings and used CSS `whitespace: pre-line` to make it retain newlines.  This feels weird.
* [ ] Highlight the current page in the navbar so we don't need to repeat the page name in an `h1`
* [ ] Put the author's profile image on the Likes page
* [ ] Centralize generation of URLs

I also rearranged the i18n strings into a more logical order.  That should have been a separate patch, sorry :)