### PR TITLE
Add view info for Private, Mentions, and Publish

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -321,11 +321,6 @@ section {
   box-sizing: border-box;
 }
 
-.viewInfo {
-  background: none;
-  white-space: pre-line; /* preserve newlines */
-}
-
 section > header {
   height: var(--line);
   display: flex;
@@ -398,7 +393,7 @@ label {
 nav > ul {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-around;
+  justify-content: space-between;
   margin: 0;
   padding: 0;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -51,8 +51,11 @@ const {
   likesView,
   listView,
   markdownView,
+  mentionsView,
   metaView,
   popularView,
+  privateView,
+  publishView,
   replyView,
   searchView,
   setLanguage,
@@ -177,7 +180,7 @@ router
     const inbox = async () => {
       const messages = await post.inbox();
 
-      return listView({ messages });
+      return privateView({ messages });
     };
     ctx.body = await inbox();
   })
@@ -382,7 +385,7 @@ router
     const mentions = async () => {
       const messages = await post.mentionsMe();
 
-      return listView({ messages });
+      return mentionsView({ messages });
     };
     ctx.body = await mentions();
   })
@@ -409,6 +412,9 @@ router
       return replyView({ messages, myFeedId });
     };
     ctx.body = await reply(message);
+  })
+  .get("/publish", async ctx => {
+    ctx.body = await publishView();
   })
   .get("/comment/:message", async ctx => {
     const { message } = ctx.params;

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -1,22 +1,43 @@
-const { a, strong } = require("hyperaxe");
+const { a, em, strong } = require("hyperaxe");
 
 module.exports = {
   en: {
     // navbar items
     extended: "Extended",
-    extendedDescription:
-      "Who: People you're not following\nWhat: Posts and comments",
+    extendedDescription: [
+      "Posts from ",
+      strong("people you don't follow"),
+      ", sorted by recency. When you follow someone you may download messages from the people they follow, and those messages show up here."
+    ],
     popular: "Popular",
-    popularDescription:
-      "Posts and comments (from anyone) with the most hearts (from people you follow)",
+    popularDescription: [
+      "Posts from people you follow, sorted by ",
+      strong("hearts"),
+      " in a given period. Hearts are counted from ",
+      em("everyone"),
+      ", including people you don't follow, so this shows posts from your friends that are popular in your extended network."
+    ],
     latest: "Latest",
-    latestDescription: "Who: People you're following\nWhat: Posts and comments",
+    latestDescription: "Posts from people you follow, sorted by recency.",
     topics: "Topics",
-    topicsDescription:
-      "Who: People you're following\nWhat: Posts.  (To see comments, click the timestamp of a post)",
+    topicsDescription: [
+      strong("Topics"),
+      " from people  you follow, sorted by recency. Select the timestamp of any post to see the rest of the thread."
+    ],
     profile: "Profile",
     mentions: "Mentions",
+    mentionsDescription: [
+      strong("Posts that mention you"),
+      " from ",
+      strong("anyone"),
+      " sorted by recency. Sometimes people may forget to @mention you, and those posts won't show up here."
+    ],
     private: "Private",
+    privateDescription: [
+      "The latest comment from ",
+      strong("private threads that include you"),
+      ", sorted by recency. Private posts are encrypted for your public key, and have a maximum of 7 recipients. Recipients cannot be added after the thread has started. Select the timestamp to view the full thread."
+    ],
     search: "Search",
     settings: "Settings",
     // post actions
@@ -49,7 +70,7 @@ module.exports = {
       a({ href: markdownUrl }, "Markdown"),
       "."
     ],
-    newMessageLabel: ({ markdownUrl, linkTarget }) => [
+    publishLabel: ({ markdownUrl, linkTarget }) => [
       "Write a new message in ",
       a(
         {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -84,6 +84,7 @@ const template = (...elements) => {
     body(
       nav(
         ul(
+          li(a({ href: "/publish" }, `📝 ${i18n.publish}`)),
           li(a({ href: "/public/latest/extended" }, `🗺️ ${i18n.extended}`)),
           li(a({ href: "/" }, `📣 ${i18n.popular}`)),
           li(a({ href: "/public/latest" }, `🐇 ${i18n.latest}`)),
@@ -388,6 +389,22 @@ exports.commentView = async ({ messages, myFeedId, parentMessage }) => {
   );
 };
 
+exports.mentionsView = ({ messages }) => {
+  return messageListView({
+    messages,
+    viewTitle: i18n.mentions,
+    viewDescription: i18n.mentionsDescription
+  });
+};
+
+exports.privateView = ({ messages }) => {
+  return messageListView({
+    messages,
+    viewTitle: i18n.private,
+    viewDescription: i18n.privateDescription
+  });
+};
+
 exports.listView = ({ messages }) =>
   template(messages.map(msg => post({ msg })));
 
@@ -395,6 +412,25 @@ exports.markdownView = ({ text }) => {
   const rawHtml = ssbMarkdown.block(text);
 
   return template(section({ class: "message" }, { innerHTML: rawHtml }));
+};
+
+exports.publishView = () => {
+  const publishForm = "/publish/";
+
+  return template(
+    section(
+      h1(i18n.publish),
+      form(
+        { action: publishForm, method: "post" },
+        label(
+          { for: "text" },
+          i18n.publishLabel({ markdownUrl, linkTarget: "_blank" })
+        ),
+        textarea({ required: true, name: "text" }),
+        button({ type: "submit" }, i18n.submit)
+      )
+    )
+  );
 };
 
 exports.metaView = ({ status, peers, theme, themeNames }) => {
@@ -541,64 +577,47 @@ exports.likesView = async ({ messages, feed, name }) => {
   );
 };
 
-exports.publicView = ({
+const messageListView = ({
   messages,
   prefix = null,
   viewTitle = null,
-  viewDescription = null
+  viewDescription = null,
+  viewElements = null
 }) => {
-  const publishForm = "/publish/";
-
   return template(
-    viewInfoBox({ viewTitle, viewDescription }),
-    prefix,
-    section(
-      header(strong(i18n.publish)),
-      form(
-        { action: publishForm, method: "post" },
-        label(
-          { for: "text" },
-          i18n.newMessageLabel({ markdownUrl, linkTarget: "_blank" })
-        ),
-        textarea({ required: true, name: "text" }),
-        button({ type: "submit" }, i18n.submit)
-      )
-    ),
+    section(h1(viewTitle), p(viewDescription), viewElements),
     messages.map(msg => post({ msg }))
   );
 };
 
-exports.popularView = ({ messages, prefix = null }) => {
-  return this.publicView({
+exports.popularView = ({ messages, prefix }) => {
+  return messageListView({
     messages,
-    prefix,
+    viewElements: prefix,
     viewTitle: i18n.popular,
     viewDescription: i18n.popularDescription
   });
 };
 
-exports.extendedView = ({ messages, prefix = null }) => {
-  return this.publicView({
+exports.extendedView = ({ messages }) => {
+  return messageListView({
     messages,
-    prefix,
     viewTitle: i18n.extended,
     viewDescription: i18n.extendedDescription
   });
 };
 
-exports.latestView = ({ messages, prefix = null }) => {
-  return this.publicView({
+exports.latestView = ({ messages }) => {
+  return messageListView({
     messages,
-    prefix,
     viewTitle: i18n.latest,
     viewDescription: i18n.latestDescription
   });
 };
 
-exports.topicsView = ({ messages, prefix = null }) => {
-  return this.publicView({
+exports.topicsView = ({ messages }) => {
+  return messageListView({
     messages,
-    prefix,
     viewTitle: i18n.topics,
     viewDescription: i18n.topicsDescription
   });
@@ -666,9 +685,9 @@ exports.searchView = ({ messages, query }) => {
 
   return template(
     section(
+      h1(i18n.search),
       form(
         { action: "/search", method: "get" },
-        header(strong(i18n.search)),
         label({ for: "query" }, i18n.searchLabel),
         searchInput,
         button(


### PR DESCRIPTION
Problem: The Private and Mentions page didn't have view labels yet, and
Publish should be its own page instead of being at the top of every
page.

Solution: Inspired by @cinnamon-bun's work to add friendly view labels,
plus a new Publish page.  This also moves the period selection from the
popular page into the view label, which felt better to me with the
previous `<section>` background. I also tried a different text format
for describing the pages, using a common form and using `<strong>` to
draw attention to any change from "Posts from people you follow, sorted
by recency" which feels like the expected default for most people.

@cinnamon-bun: To me this feels like a fun back-and-forth where I'm
riffing on your work and hoping that you do the same, but if it feels
wrong/rude please let me know. Trying to work on designs with a system
like C4 is super new for me and I wouldn't be surprised if there are
pain points to fix!

Resolves https://github.com/fraction/oasis/issues/160
Resolves https://github.com/fraction/oasis/issues/163


![Screenshot_2020-02-04 Oasis](https://user-images.githubusercontent.com/537700/73804416-9b937000-4778-11ea-8eb7-9f42b5417bd3.png)
