### PR TITLE
Fix socialFilter() to change `{ me = null }`

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -269,7 +269,7 @@ module.exports = cooler => {
   const socialFilter = async ({
     following = null,
     blocking = false,
-    me = false
+    me = null
   } = {}) => {
     const ssb = await cooler.connect();
     const { id } = ssb;


### PR DESCRIPTION
Problem: The socialFilter was hiding posts published by the user, which
felt weird and uncanny.

Solution: Fix the default so that `{ me }` isn't hidden from a view
unless the model specifically wants that to happen.

Resolves https://github.com/fraction/oasis/issues/156