### PR TITLE
Remove nosniff from blob URLs

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -41,8 +41,15 @@ module.exports = ({ host, port, middleware }) => {
     // Disallow <iframe> embeds from other domains.
     ctx.set("X-Frame-Options", "SAMEORIGIN");
 
-    // Disallow browsers overwriting declared media types.
-    ctx.set("X-Content-Type-Options", "nosniff");
+    const isBlobPath = ctx.path.startsWith("/blob/");
+
+    if (isBlobPath === false) {
+      // Disallow browsers overwriting declared media types.
+      //
+      // This should only happen on non-blob URLs.
+      // See: https://github.com/fraction/oasis/issues/138
+      ctx.set("X-Content-Type-Options", "nosniff");
+    }
 
     // Disallow sharing referrer with other domains.
     ctx.set("Referrer-Policy", "same-origin");
@@ -54,9 +61,9 @@ module.exports = ({ host, port, middleware }) => {
       const referer = ctx.request.header.referer;
       ctx.assert(referer != null, `HTTP ${ctx.method} must include referer`);
       const refererUrl = new URL(referer);
-      const isBlobUrl = refererUrl.pathname.startsWith("/blob/");
+      const isBlobReferer = refererUrl.pathname.startsWith("/blob/");
       ctx.assert(
-        isBlobUrl === false,
+        isBlobReferer === false,
         `HTTP ${ctx.method} from blob URL not allowed`
       );
     }


### PR DESCRIPTION
Problem: We use nosniff to keep the web browser from getting confused
about what kinds of content we're serving in Oasis, but this causes
problems for blob URLs that have arbitrary data.

Solution: Remove nosniff on blob URLs to let the browser figure out what
kind of content we're serving.

Resolves https://github.com/fraction/oasis/issues/138

Now works in Chromium!

![Screenshot from 2020-02-05 17-02-28](https://user-images.githubusercontent.com/537700/73897053-a530dc80-4839-11ea-923e-983933c803cf.png)
