### PR TITLE
Add --public option for public viewers

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -31,6 +31,12 @@ module.exports = () =>
       default: 3000,
       type: "number"
     })
+    .options("public", {
+      describe:
+        "Assume Oasis is being hosted publicly, disable HTTP POST and redact messages from people who haven't given consent for public web hosting.",
+      default: false,
+      type: "boolean"
+    })
     .options("debug", {
       describe: "Use verbose output for debugging",
       default: false,


### PR DESCRIPTION
Problem: It's hard to show off Oasis or take screenshots without
respecting the `publicWebHosting` convention. While `publicWebHosting`
lacks a formal specification and I'm a bit confused about what its
boundaries are, it sounds like some of our friends would like to avoid
us publishing any of their content on the public web if we can avoid it.

Solution: Add --public option that turns Oasis into a public web viewer.
This makes it **slightly inconvenient** to see these public posts, but
should absolutely not be mistaken for a privacy guarantee. Only HTTP GET
endpoints are allowed, so random people can't publish or change
settings. The name, avatar, description, content warning, and message
contents are replaced with "Redacted", but again, this is all public
information that we can never provide real privacy for.

Resolves https://github.com/fraction/oasis/issues/48

![Screenshot_2020-02-08 Oasis(1)](https://user-images.githubusercontent.com/537700/74090561-a17f9e80-4a61-11ea-93c0-d78b29e55d69.png)
