### PR TITLE
Add basic robots.txt to keep search engines away

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,9 @@ router
   .get("/", async ctx => {
     ctx.redirect("/public/popular/day");
   })
+  .get("/robots.txt", ctx => {
+    ctx.body = "User-agent: *\nDisallow: /";
+  })
   .get("/public/popular/:period", async ctx => {
     const { period } = ctx.params;
     const publicPopular = async ({ period }) => {


### PR DESCRIPTION
Problem: Search engines are controversial and my understanding is that
most people on SSB don't want their messages indexed by search engines.
If that's the case, we should probably disable it.

Solution: Add basic `robots.txt` file to ask search engines to stay away
and please don't save info. I'm concerned that, like `publicWebHosting`
redactions, it gives a false sense of privacy, but it seems like this is
probably what most people would want?