### PR TITLE
Fix bug where others could still change your name

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -49,7 +49,7 @@ module.exports = ({ cooler, isPublic }) => {
         {
           $filter: {
             dest: feedId,
-            value: { content: { type: "about", about: feedId } }
+            value: { author: feedId, content: { type: "about", about: feedId } }
           }
         }
       ]


### PR DESCRIPTION
Problem: There was one missing component that would filter out nicknames
from other people. This caused a problem where we could get a name for a
feed but it could've been assigned by a friend, which we don't want
right now.

Solution: Ensure that the subject of the message is the same as the
author of the message.