### PR TITLE
Fix extended page so it doesn't show your posts

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -744,7 +744,8 @@ module.exports = ({ cooler, isPublic }) => {
       const source = await cooler.read(ssb.messagesByType, options);
 
       const extendedFilter = await socialFilter({
-        following: false
+        following: false,
+        me: false
       });
 
       const messages = await new Promise((resolve, reject) => {


### PR DESCRIPTION
Problem: Your posts show up in Extended, which is unexpected because I'm
the center of my network, not some rando at the periphery.

Solution: Use the `socialFilter()` function to make sure that the
extended view only shows people in your extended network, not you. :)