### PR TITLE
Fix popular page to only show posts from following

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -836,7 +836,6 @@ module.exports = ({ cooler, isPublic }) => {
       const messages = await new Promise((resolve, reject) => {
         pull(
           source,
-          followingFilter,
           pull.filter(msg => {
             return (
               msg.value.timestamp > earliest &&
@@ -912,6 +911,7 @@ module.exports = ({ cooler, isPublic }) => {
                     message // avoid private messages (!)
                   ) => message && typeof message.value.content !== "string"
                 ),
+                followingFilter,
                 pull.collect((err, collectedMessages) => {
                   if (err) {
                     reject(err);


### PR DESCRIPTION
Problem: Previously we were only counting likes from people you follow,
but showing messages from anyone. This was backward, and could
potentially show messages from blocked authors that were liked by people
you follow.

Solution: Move the `socialFilter()` invocation down the pipeline so that
it sorts the output messages, not the likes.

cc: @georgeowell could you verify that this resolves #202 
