### PR TITLE
Remove automatic mentions from private threads

### DIFF
--- a/src/views/index.js
+++ b/src/views/index.js
@@ -394,7 +394,7 @@ exports.commentView = async ({ messages, myFeedId, parentMessage }) => {
           required: true,
           name: "text"
         },
-        markdownMention
+        isPrivate ? null : markdownMention
       ),
       button(
         {


### PR DESCRIPTION
Problem: When replying to a private thread we already know who the
recipients are, and they're already going to get the notification, so
there's really no reason to add a mention.

Solution: Remove the mention when the message is private.