### PR TITLE
Use color emoji in Markdown posts

### DIFF
--- a/src/views/markdown.js
+++ b/src/views/markdown.js
@@ -3,6 +3,7 @@
 const md = require("ssb-markdown");
 const ssbMessages = require("ssb-msgs");
 const ssbRef = require("ssb-ref");
+const { span } = require("hyperaxe");
 
 /** @param {{ link: string}[]} mentions */
 const toUrl = mentions => {
@@ -51,5 +52,6 @@ const toUrl = mentions => {
  */
 module.exports = (input, mentions = []) =>
   md.block(input, {
-    toUrl: toUrl(mentions)
+    toUrl: toUrl(mentions),
+    emoji: character => span({ class: "emoji" }, character).outerHTML
   });


### PR DESCRIPTION
Problem: Emoji from Markdown posts were being displayed in the default
font, which doesn't always use color emoji.

Solution: Use the `.emoji` CSS class on those emoji to ensure that the
correct emoji font is used.
