### PR TITLE
Hide custom publish behind publish menu

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,17 +52,17 @@ const {
   extendedView,
   latestView,
   likesView,
-  rawJsonView,
   listView,
   markdownView,
   mentionsView,
-  settingsView,
   popularView,
   privateView,
+  publishCustomView,
   publishView,
   replyView,
   searchView,
   setLanguage,
+  settingsView,
   topicsView
 } = require("./views");
 
@@ -231,8 +231,8 @@ router
     };
     ctx.body = await profile();
   })
-  .get("/raw_json/", async ctx => {
-    ctx.body = await rawJsonView();
+  .get("/publish/custom/", async ctx => {
+    ctx.body = await publishCustomView();
   })
   .get("/json/:message", async ctx => {
     if (config.public) {
@@ -513,10 +513,10 @@ router
     ctx.body = await publish({ text, contentWarning });
     ctx.redirect("/");
   })
-  .post("/publish_json/", koaBody(), async ctx => {
+  .post("/publish/custom", koaBody(), async ctx => {
     const text = String(ctx.request.body.text);
     const obj = JSON.parse(text);
-    ctx.body = await post.publish_json(obj);
+    ctx.body = await post.publishCustom(obj);
     ctx.redirect(`/thread/${encodeURIComponent(ctx.body.key)}`);
   })
   .post("/follow/:feed", koaBody(), async ctx => {

--- a/src/models.js
+++ b/src/models.js
@@ -1148,7 +1148,7 @@ module.exports = ({ cooler, isPublic }) => {
       debug("Published: %O", body);
       return ssb.publish(body);
     },
-    publish_json: async options => {
+    publishCustom: async options => {
       const ssb = await cooler.open();
       debug("Published: %O", options);
       return ssb.publish(options);

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -1,4 +1,4 @@
-const { a, em, strong } = require("hyperaxe");
+const { a, em, strong, code } = require("hyperaxe");
 
 module.exports = {
   en: {
@@ -59,6 +59,11 @@ module.exports = {
     likedBy: "'s likes",
     // composer
     publish: "Publish",
+    publishCustomDescription: [
+      "Publish a custom message by entering ",
+      a({ href: "https://en.wikipedia.org/wiki/JSON" }, "JSON"),
+      " below. This may be useful for prototyping or publishing messages that Oasis doesn't support. This message cannot be edited or deleted."
+    ],
     commentWarning: [
       " Messages cannot be edited or deleted. To respond to an individual message, select ",
       strong("reply"),
@@ -82,6 +87,18 @@ module.exports = {
       ),
       ". Messages cannot be edited or deleted."
     ],
+    publishCustomInfo: ({ href }) => [
+      "If you're an advanced user, you can also ",
+      a({ href }, "publish a custom message"),
+      "."
+    ],
+    publishBasicInfo: ({ href }) => [
+      "If you're not an advanced user, you should ",
+      a({ href }, "publish a basic post"),
+      "."
+    ],
+    publishCustom: "Publish custom",
+
     replyLabel: ({ markdownUrl }) => [
       "Write a ",
       strong("public reply"),

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -110,8 +110,7 @@ const template = (...elements) => {
           navLink({ href: "/mentions", emoji: "💬", text: i18n.mentions }),
           navLink({ href: "/inbox", emoji: "✉️", text: i18n.private }),
           navLink({ href: "/search", emoji: "🔍", text: i18n.search }),
-          navLink({ href: "/settings", emoji: "⚙", text: i18n.settings }),
-          navLink({ href: "/raw_json", emoji: "👽", text: i18n.manualMode })
+          navLink({ href: "/settings", emoji: "⚙", text: i18n.settings })
         )
       ),
       main({ id: "content" }, elements)
@@ -423,39 +422,36 @@ exports.privateView = ({ messages }) => {
   });
 };
 
-exports.rawJsonView = async () => {
-  const action = `/publish_json`;
+exports.publishCustomView = async () => {
+  const action = "/publish/custom";
   const method = "post";
 
   return template(
-    p(
-      "Publish any  ",
-      a({ href: "https://en.wikipedia.org/wiki/JSON" }, "JSON"),
-      " message on your feed. This can be useful for prototyping,",
-      " or for doing things that Oasis doesn't support (yet). ",
-      "To insert line breaks into strings, use \\n instead of ",
-      'just hitting enter, and \\" for quotes.'
-    ),
-    form(
-      { action, method },
-      textarea(
-        {
-          autofocus: true,
-          required: true,
-          name: "text"
-        },
-        "{\n",
-        '    "type": "test_type",\n',
-        '    "your_field_name": "whatever you want!"\n',
-        "}"
-      ),
-      button(
-        {
-          type: "submit"
-        },
-        "Publish"
+    section(
+      h1(i18n.publishCustom),
+      p(i18n.publishCustomDescription),
+      form(
+        { action, method },
+        textarea(
+          {
+            autofocus: true,
+            required: true,
+            name: "text"
+          },
+          "{\n",
+          '  "type": "test",\n',
+          '  "hello": "world"\n',
+          "}"
+        ),
+        button(
+          {
+            type: "submit"
+          },
+          i18n.submit
+        )
       )
-    )
+    ),
+    p(i18n.publishBasicInfo({ href: "/publish" }))
   );
 };
 
@@ -490,7 +486,8 @@ exports.publishView = () => {
         }),
         button({ type: "submit" }, i18n.submit)
       )
-    )
+    ),
+    p(i18n.publishCustomInfo({ href: "/publish/custom" }))
   );
 };
 


### PR DESCRIPTION
Problem: The new custom publish was called 'Manual mode', which I'm
afraid isn't super easy to understand for people who don't already know
SSB. The custom publishing page didn't follow the same conventions as
other pages, either.

Solution: Hide the custom publish mode behind the publish page, with a
warning that it's for 'advanced users', and ensure that it uses the same
conventions and visual styles as other pages and code around the app.

