### PR TITLE
No more `null` for unknown names and descriptions

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -89,10 +89,12 @@ module.exports = ({ cooler, isPublic }) => {
         return "Redacted";
       }
 
-      return getAbout({
-        key: "name",
-        feedId
-      });
+      return (
+        (await getAbout({
+          key: "name",
+          feedId
+        })) || feedId.slice(1, 1 + 8)
+      ); // First 8 chars of public key
     },
     image: async feedId => {
       if (isPublic && (await models.about.publicWebHosting(feedId)) === false) {
@@ -118,10 +120,11 @@ module.exports = ({ cooler, isPublic }) => {
         return "Redacted";
       }
 
-      const raw = await getAbout({
-        key: "description",
-        feedId
-      });
+      const raw =
+        (await getAbout({
+          key: "description",
+          feedId
+        })) || "";
       return raw;
     }
   };


### PR DESCRIPTION
Problem: When we couldn't figure out someone's name or description we
were using `null`, which got coerced to a string and ended up with us
calling people `"@null"`. Not ideal!

Solution: Support a use-case where someone doesn't have a profile
description or a name, and use the first 8 characters of their public
key for their name if they haven't set a name themselves.