### PR TITLE
Show a preview of comments in listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ dist/
 node_modules/
 tmp/
 yarn.lock
+
+# Visual Studio Code
+launch.json
+*.code-workspace

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -331,6 +331,7 @@ section {
   word-wrap: break-word;
   background: var(--bg);
   width: 100%;
+  max-width: var(--measure);
   box-sizing: border-box;
 }
 
@@ -396,6 +397,32 @@ section > footer > * {
 
 section > footer > form > button.liked {
   color: var(--red);
+}
+
+.post-aside-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+@media (min-width: 80rem) {
+  .post-aside-wrapper {
+    flex-direction: row;
+  }
+}
+
+.post-aside  {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
+  padding-left: var(--micro);
+  margin: var(--whole) 0;
+}
+
+.post-aside section  {
+  max-width: var(--peta);
+  margin: 0 0 var(--micro) 0;
 }
 
 label {
@@ -495,8 +522,7 @@ hr {
     margin-bottom: var(--whole);
   }
   main {
-    width: 100%;
-    max-width: var(--measure);
+    width: 85vw;
   }
   body {
     display: flex;

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -411,7 +411,7 @@ section > footer > form > button.liked {
   }
 }
 
-.post-aside  {
+.post-aside {
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
@@ -420,7 +420,7 @@ section > footer > form > button.liked {
   margin: var(--whole) 0;
 }
 
-.post-aside section  {
+.post-aside section {
   max-width: var(--peta);
   margin: 0 0 var(--micro) 0;
 }

--- a/src/models.js
+++ b/src/models.js
@@ -903,10 +903,14 @@ module.exports = ({ cooler, isPublic }) => {
                 pull.map(([key]) => key),
                 pullParallelMap(async (key, cb) => {
                   try {
-                    const msg = await post.get(key);
-                    cb(null, msg);
+                    const msg = await post.get(key)
+
+                    // Retrieve a preview of this post's comments / thread
+                    const thread = await post.fromThread(key)
+                    msg.thread = await transform(ssb, thread, myFeedId)
+                    cb(null, msg)
                   } catch (e) {
-                    cb(null, null);
+                    cb(null, null)
                   }
                 }),
                 pull.filter(
@@ -917,12 +921,12 @@ module.exports = ({ cooler, isPublic }) => {
                 followingFilter,
                 pull.collect((err, collectedMessages) => {
                   if (err) {
-                    reject(err);
+                    reject(err)
                   } else {
-                    resolve(transform(ssb, collectedMessages, myFeedId));
+                    resolve(transform(ssb, collectedMessages, myFeedId))
                   }
                 })
-              );
+              )
             }
           )
         );

--- a/src/models.js
+++ b/src/models.js
@@ -903,14 +903,14 @@ module.exports = ({ cooler, isPublic }) => {
                 pull.map(([key]) => key),
                 pullParallelMap(async (key, cb) => {
                   try {
-                    const msg = await post.get(key)
+                    const msg = await post.get(key);
 
                     // Retrieve a preview of this post's comments / thread
-                    const thread = await post.fromThread(key)
-                    msg.thread = await transform(ssb, thread, myFeedId)
-                    cb(null, msg)
+                    const thread = await post.fromThread(key);
+                    msg.thread = await transform(ssb, thread, myFeedId);
+                    cb(null, msg);
                   } catch (e) {
-                    cb(null, null)
+                    cb(null, null);
                   }
                 }),
                 pull.filter(
@@ -921,12 +921,12 @@ module.exports = ({ cooler, isPublic }) => {
                 followingFilter,
                 pull.collect((err, collectedMessages) => {
                   if (err) {
-                    reject(err)
+                    reject(err);
                   } else {
-                    resolve(transform(ssb, collectedMessages, myFeedId))
+                    resolve(transform(ssb, collectedMessages, myFeedId));
                   }
                 })
-              )
+              );
             }
           )
         );

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -129,7 +129,7 @@ const postInAside = msg => {
     key: encodeURIComponent(msg.key),
     author: encodeURIComponent(msg.value.author),
     parent: encodeURIComponent(msg.value.content.root)
-  }
+  };
 
   const url = {
     author: `/author/${encoded.author}`,
@@ -140,45 +140,46 @@ const postInAside = msg => {
     json: `/json/${encoded.key}`,
     reply: `/reply/${encoded.key}`,
     comment: `/comment/${encoded.key}`
-  }
+  };
 
-  const isPrivate = Boolean(msg.value.meta.private)
-  const isRoot = msg.value.content.root == null
-  const isFork = msg.value.meta.postType === "reply"
-  const hasContentWarning = typeof msg.value.content.contentWarning === "string"
+  const isPrivate = Boolean(msg.value.meta.private);
+  const isRoot = msg.value.content.root == null;
+  const isFork = msg.value.meta.postType === "reply";
+  const hasContentWarning =
+    typeof msg.value.content.contentWarning === "string";
   const isThreadTarget = Boolean(
     lodash.get(msg, "value.meta.thread.target", false)
-  )
+  );
 
   // TODO: I think this is actually true for both replies and comments.
-  const isReply = Boolean(lodash.get(msg, "value.meta.thread.reply", false))
+  const isReply = Boolean(lodash.get(msg, "value.meta.thread.reply", false));
 
-  const timeAgo = msg.value.meta.timestamp.received.since.replace("~", "")
+  const timeAgo = msg.value.meta.timestamp.received.since.replace("~", "");
 
   const markdownContent = markdown(
     msg.value.content.text,
     msg.value.content.mentions
-  )
+  );
 
   const likeButton = msg.value.meta.voted
     ? { value: 0, class: "liked" }
-    : { value: 1, class: null }
+    : { value: 1, class: null };
 
-  const likeCount = msg.value.meta.votes.length
+  const likeCount = msg.value.meta.votes.length;
 
-  const messageClasses = []
+  const messageClasses = [];
 
   if (isPrivate) {
-    messageClasses.push("private")
+    messageClasses.push("private");
   }
 
   if (isThreadTarget) {
-    messageClasses.push("thread-target")
+    messageClasses.push("thread-target");
   }
 
   if (isReply) {
     // True for comments too, I think
-    messageClasses.push("reply")
+    messageClasses.push("reply");
   }
 
   const postOptions = {
@@ -186,9 +187,9 @@ const postInAside = msg => {
     comment: i18n.commentDescription({ parentUrl: url.parent }),
     reply: i18n.replyDescription({ parentUrl: url.parent }),
     mystery: i18n.mysteryDescription
-  }
+  };
 
-  const isMarkdownEmpty = md => md === "<p>undefined</p>\n"
+  const isMarkdownEmpty = md => md === "<p>undefined</p>\n";
   const articleElement = isMarkdownEmpty(markdownContent)
     ? article(
         { class: "content" },
@@ -197,11 +198,11 @@ const postInAside = msg => {
             .value
         })
       )
-    : article({ class: "content", innerHTML: markdownContent })
+    : article({ class: "content", innerHTML: markdownContent });
 
   const articleContent = hasContentWarning
     ? details(summary(msg.value.content.contentWarning), articleElement)
-    : articleElement
+    : articleElement;
 
   return section(
     {
@@ -241,13 +242,13 @@ const postInAside = msg => {
       isPrivate || isRoot || isFork ? null : a({ href: url.reply }, i18n.reply),
       a({ href: url.json }, i18n.json)
     )
-  )
-}
+  );
+};
 
 /**
- * Render a section containing a link that takes users to the context for a 
+ * Render a section containing a link that takes users to the context for a
  * thread preview.
- * 
+ *
  * @param {Array} thread with SSB message objects
  * @param {Boolean} isComment true if this is shown in the context of a comment
  *  instead of a post
@@ -256,54 +257,57 @@ const continueThreadComponent = (thread, isComment) => {
   const encoded = {
     next: encodeURIComponent(thread[THREAD_PREVIEW_LENGTH + 1].key),
     parent: encodeURIComponent(thread[0].key)
-  }
-  const left = thread.length - (THREAD_PREVIEW_LENGTH + 1)
-  let continueLink
+  };
+  const left = thread.length - (THREAD_PREVIEW_LENGTH + 1);
+  let continueLink;
   if (isComment == false) {
-    continueLink = `/thread/${encoded.parent}#${encoded.next}`
+    continueLink = `/thread/${encoded.parent}#${encoded.next}`;
     return a(
       { href: continueLink },
       `continue reading ${left} more comment${left === 1 ? "" : "s"}`
-    )
+    );
   } else {
-    continueLink = `/thread/${encoded.parent}`
-    return a({ href: continueLink }, "read the rest of the thread")
+    continueLink = `/thread/${encoded.parent}`;
+    return a({ href: continueLink }, "read the rest of the thread");
   }
-}
+};
 
 /**
  * Render an aside with a preview of comments on a message
- * 
+ *
  * For posts, up to three comments are shown, for comments, up to 3 messages
  * directly following this one in the thread are displayed. If there are more
  * messages in the thread, a link is rendered that links to the rest of the
  * context.
- * 
+ *
  * @param {Object} post for which to display the aside
  */
 const postAside = ({ key, value, thread }) => {
-  if (thread == null) return null
+  if (thread == null) return null;
 
-  const isComment = value.meta.postType === "comment"
+  const isComment = value.meta.postType === "comment";
 
-  let postsToShow
+  let postsToShow;
   if (isComment) {
-    const commentPosition = thread.findIndex(msg => msg.key === key)
+    const commentPosition = thread.findIndex(msg => msg.key === key);
     postsToShow = thread.slice(
       commentPosition + 1,
       Math.min(commentPosition + (THREAD_PREVIEW_LENGTH + 1), thread.length)
-    )
+    );
   } else {
-    postsToShow = thread.slice(1, Math.min(thread.length, (THREAD_PREVIEW_LENGTH + 1)))
+    postsToShow = thread.slice(
+      1,
+      Math.min(thread.length, THREAD_PREVIEW_LENGTH + 1)
+    );
   }
 
-  const fragments = postsToShow.map(postInAside)
+  const fragments = postsToShow.map(postInAside);
 
-  if (thread.length > (THREAD_PREVIEW_LENGTH + 1)) {
-    fragments.push(section(footer(continueThreadComponent(thread, isComment))))
+  if (thread.length > THREAD_PREVIEW_LENGTH + 1) {
+    fragments.push(section(footer(continueThreadComponent(thread, isComment))));
   }
-  return div({ class: "post-aside" }, fragments)
-}
+  return div({ class: "post-aside" }, fragments);
+};
 
 const post = ({ msg }) => {
   const encoded = {
@@ -446,11 +450,11 @@ const post = ({ msg }) => {
       isPrivate || isRoot || isFork ? null : a({ href: url.reply }, i18n.reply),
       a({ href: url.json }, i18n.json)
     )
-  )
+  );
 
-  const aside = postAside(msg)
-  const wrapper = div({ class: "post-aside-wrapper" }, fragment, aside)
-  return wrapper
+  const aside = postAside(msg);
+  const wrapper = div({ class: "post-aside-wrapper" }, fragment, aside);
+  return wrapper;
 };
 
 exports.authorView = ({


### PR DESCRIPTION
First of all, I am not familiar with the C4 contribution process, please be patient with me :) I just built this for myself today because I wanted to get familiar with the Oasis codebase and wanted to have this feature myself. If it's not in your vision for Oasis, no problem.

**What's the problem you solved?**

On a large monitor, Oasis is only using a fraction of the horizontal space. Also, I was missing Patchworks feature to show a preview of comments on each post in the timeline.

Example:

![image](https://user-images.githubusercontent.com/278463/74611100-53216e00-50f9-11ea-9486-f9b91af56acb.png)

**What solution are you recommending?**

Here I have added a preview of comments on each post in the timeline, which is shown to the side of the original post on large screens and below on small screens (as in Patchwork).

Examples:

![image](https://user-images.githubusercontent.com/278463/74611341-1f474800-50fb-11ea-9c54-440508c81e1d.png)

![image](https://user-images.githubusercontent.com/278463/74611327-0048b600-50fb-11ea-97ce-9efc70b4fcc5.png)


**Caveats**

- The popular page now takes a long time to load (56sec vs 12sec before). Both times are too long to be usable though. I wonder what would be a good way to speed up loading of the page but I feel like I don't know enough about the architecture and also that this would be out of scope for this maybe (?).
- I duplicated a bit of code here that I would like to refactor before this is mergeable. I wanted to hear whether this approach is even wanted before doing the work though. Hope you understand!
- I had a problem committing my changes when Git's commit hook would ask me to run prettier on the code first. As there is no prettier config in the project, that would change all of the rest of the codebase, which is probably not what is intended. So I suggest to add a `.prettierrc.js`.