### PR TITLE
Replace messagesByType() with SSB-Query read

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -705,12 +705,23 @@ module.exports = ({ cooler, isPublic }) => {
 
       const myFeedId = ssb.id;
 
-      const options = configure({
-        type: "post",
-        private: false
-      });
-
-      const source = ssb.messagesByType(options);
+      const source = ssb.query.read(
+        configure({
+          query: [
+            {
+              $filter: {
+                value: {
+                  content: {
+                    type: "post"
+                  }
+                }
+              }
+            }
+          ],
+          index: "DTA",
+          private: false
+        })
+      );
       const followingFilter = await socialFilter({ following: true });
 
       const messages = await new Promise((resolve, reject) => {
@@ -740,12 +751,23 @@ module.exports = ({ cooler, isPublic }) => {
 
       const myFeedId = ssb.id;
 
-      const options = configure({
-        type: "post",
-        private: false
-      });
-
-      const source = ssb.messagesByType(options);
+      const source = ssb.query.read(
+        configure({
+          query: [
+            {
+              $filter: {
+                value: {
+                  content: {
+                    type: "post"
+                  }
+                }
+              }
+            }
+          ],
+          index: "DTA",
+          private: false
+        })
+      );
 
       const extendedFilter = await socialFilter({
         following: false,
@@ -775,12 +797,23 @@ module.exports = ({ cooler, isPublic }) => {
 
       const myFeedId = ssb.id;
 
-      const options = configure({
-        type: "post",
-        private: false
-      });
-
-      const source = ssb.messagesByType(options);
+      const source = ssb.query.read(
+        configure({
+          query: [
+            {
+              $filter: {
+                value: {
+                  content: {
+                    type: "post"
+                  }
+                }
+              }
+            }
+          ],
+          index: "DTA",
+          private: false
+        })
+      );
 
       const extendedFilter = await socialFilter({
         following: true
@@ -827,13 +860,25 @@ module.exports = ({ cooler, isPublic }) => {
       const now = new Date();
       const earliest = Number(now) - 1000 * 60 * 60 * 24 * periodDict[period];
 
-      const options = configure({
-        type: "vote",
-        gt: earliest,
-        private: false
-      });
-
-      const source = ssb.messagesByType(options);
+      const source = ssb.query.read(
+        configure({
+          query: [
+            {
+              $filter: {
+                value: {
+                  timestamp: { $gte: earliest },
+                  content: {
+                    type: "vote"
+                  }
+                },
+                timestamp: { $gte: earliest }
+              }
+            }
+          ],
+          index: "DTA",
+          private: false
+        })
+      );
       const followingFilter = await socialFilter({ following: true });
 
       const messages = await new Promise((resolve, reject) => {
@@ -841,7 +886,6 @@ module.exports = ({ cooler, isPublic }) => {
           source,
           pull.filter(msg => {
             return (
-              msg.value.timestamp > earliest &&
               typeof msg.value.content === "object" &&
               typeof msg.value.content.vote === "object" &&
               typeof msg.value.content.vote.link === "string" &&


### PR DESCRIPTION
Problem: The `messagesByType()` queries don't let us sort by asserted
time, which means that we can get messages from a long time ago that
just ended up on our computer.

Solution: Use SSB-Query everywhere. The query syntax isn't really my
favorite but it lets us make declarative queries that respect the
asserted timestamp instead of just the received timestamp.