### PR TITLE
Redirect to Latest after publishing new message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -520,13 +520,13 @@ router
       });
     };
     ctx.body = await publish({ text, contentWarning });
-    ctx.redirect("/");
+    ctx.redirect("/public/latest");
   })
   .post("/publish/custom", koaBody(), async ctx => {
     const text = String(ctx.request.body.text);
     const obj = JSON.parse(text);
     ctx.body = await post.publishCustom(obj);
-    ctx.redirect(`/thread/${encodeURIComponent(ctx.body.key)}`);
+    ctx.redirect(`/public/latest`);
   })
   .post("/follow/:feed", koaBody(), async ctx => {
     const { feed } = ctx.params;


### PR DESCRIPTION
Problem: After publishing a message you were redirected to the Popular
view, which wasn't good feedback that your message had been published.

Solution: After publishing a new message, redirect to the Latest view.