### PR TITLE
Remove image border

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -235,7 +235,6 @@ section img,
 section video {
   max-width: 100%;
   max-height: 100vh;
-  border: var(--pico) solid var(--bg-status);
   border-radius: var(--common-radius);
   box-sizing: border-box;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,6 @@ fs.readFile(readmePath, "utf8").then(text => {
 
 fs.readFile(packagePath, "utf8").then(text => {
   config.version = JSON.parse(text).version;
-  console.log(config.version);
 });
 
 router


### PR DESCRIPTION
Problem: I added an image border to try to make it easier to see the
boundaries of images but it's not really necessary and at least one
person didn't love it, which is grounds for removal.

Solution: Get it out of here! This commit removes the image border and
also removes a random `console.log()` that shouldn't have been left in
`src/index.js`.