### PR TITLE
Remove private messages from Mentions

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -562,7 +562,9 @@ module.exports = ({ cooler, isPublic }) => {
         customOptions,
         ssb,
         query,
-        filter: msg => msg.value.author !== myFeedId
+        filter: msg =>
+          msg.value.author !== myFeedId &&
+          lodash.get(msg, "value.meta.private") !== true
       });
 
       return messages;


### PR DESCRIPTION
Problem: Private messages should only be showing up in the Private page,
not the Mentions page, but right now they're showing up in Mentions.

Solution: Add a check to ensure that Mentions doesn't have any private
messages.