### PR TITLE
Update SSB-Mentions and remove workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1782,14 +1782,6 @@
         "regexp.prototype.flags": "^1.2.0"
       }
     },
-    "deep-equals": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/deep-equals/-/deep-equals-0.0.2.tgz",
-      "integrity": "sha1-IcFkxV0aUIAtFdlPgB0yWFqZ8M4=",
-      "requires": {
-        "ramda": "^0.23.0"
-      }
-    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -4413,6 +4405,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.shuffle": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz",
@@ -6141,11 +6138,6 @@
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
     },
-    "ramda": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.23.0.tgz",
-      "integrity": "sha1-zNE//3NJepOXTj6GMnv9h71ujis="
-    },
     "randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
@@ -7299,11 +7291,11 @@
       "integrity": "sha512-N1Cxm9WscGD9VEZrWbF2amyQai2U2g9gtq57W5zTqbhlQTLUUvl84U9A6fg6GPkECnUXadulnTw+mMYVkLLHjQ=="
     },
     "ssb-mentions": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ssb-mentions/-/ssb-mentions-0.5.1.tgz",
-      "integrity": "sha512-SIllP6yois6Gs33XuFuamPpvm3+jYiSlC5okf06eFuOT9spag41Pjp9Yo1Jrm86MLsb/Bp8tQnsHAwzhG0nHEA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ssb-mentions/-/ssb-mentions-0.5.2.tgz",
+      "integrity": "sha512-+1lslVCkfnmJOlswJluia+70K5tTLzwRxbLmluvV0rf2KW5T4DIXBPuAhB3vBsP26emAcTHEOj7QtD8iQ9VWtA==",
       "requires": {
-        "deep-equals": "0.0.2",
+        "lodash.isequal": "^4.5.0",
         "ssb-marked": "^0.7.0",
         "ssb-ref": "^2.11.0"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ssb-client": "^4.9.0",
     "ssb-config": "^3.4.4",
     "ssb-markdown": "^6.0.3",
-    "ssb-mentions": "^0.5.0",
+    "ssb-mentions": "^0.5.2",
     "ssb-msgs": "^5.2.0",
     "ssb-ref": "^2.13.9",
     "ssb-tangle": "^1.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -505,8 +505,7 @@ router
     const text = String(ctx.request.body.text);
     const publishReply = async ({ message, text }) => {
       // TODO: rename `message` to `parent` or `ancestor` or similar
-      const mentions =
-        ssbMentions(text).filter(mention => mention != null) || undefined;
+      const mentions = ssbMentions(text) || undefined;
 
       const parent = await post.get(message);
       return post.reply({
@@ -522,8 +521,7 @@ router
     const text = String(ctx.request.body.text);
     const publishComment = async ({ message, text }) => {
       // TODO: rename `message` to `parent` or `ancestor` or similar
-      const mentions =
-        ssbMentions(text).filter(mention => mention != null) || undefined;
+      const mentions = ssbMentions(text) || undefined;
       const parent = await meta.get(message);
 
       return post.comment({
@@ -543,8 +541,7 @@ router
       rawContentWarning.length > 0 ? rawContentWarning : undefined;
 
     const publish = async ({ text, contentWarning }) => {
-      const mentions =
-        ssbMentions(text).filter(mention => mention != null) || undefined;
+      const mentions = ssbMentions(text) || undefined;
 
       return post.root({
         text,


### PR DESCRIPTION
Problem: We've been using a workaround to filter the results of
SSB-Mentions, but that's just been fixed upstream and so we don't need
the workaround anymore.

Solution: Update the SSB-Mentions package and remove the workaround.

See: https://github.com/ssbc/ssb-mentions/pull/17