### PR TITLE
Add support for Unix socket with noauth

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -28,6 +28,7 @@
     "multiserver",
     "muxrpc",
     "nanohtml",
+    "noauth",
     "nosniff",
     "paramap",
     "patchbay",


### PR DESCRIPTION
Problem: We're doing tons of unnecessary cryptography by encrypting the
connection between the "client" and "server", which are often running in
the same process.

Solution: Instead of connecting to the SSB service over TCP and
encrypting the stream, just connect over a socket (supported on Windows,
macOS, and Linux) and don't bother encrypting anything. This is what
Patchwork and Patchbay do already, and since our secret is at
`~/.ssb/secret` then we should be comfortable with `~/.ssb/socket` being
a trusted file where access implies authentication.

Local tests suggest that when sodium-native is available, this commit
reduces the time to render the 'Popular (Day)' page by 17%, but when we
have to fall back to JavaScript cryptography the same page now takes 30%
less time to render. My intuition is that this improvement is more
dramatic on mobile, but requires further testing before we can pat
ourselves on the back too much. :)
