### PR TITLE
Read settings from $XDG_CONFIG_HOME/oasis/config.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,6 +2075,11 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
+    "env-paths": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+    },
     "epidemic-broadcast-trees": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/epidemic-broadcast-trees/-/epidemic-broadcast-trees-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@fraction/base16-css": "^1.1.0",
     "@fraction/flotilla": "^4.0.0",
     "debug": "^4.1.1",
+    "env-paths": "^2.2.0",
     "highlight.js": "^9.18.1",
     "hyperaxe": "^1.3.0",
     "is-svg": "^4.2.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,8 +1,9 @@
 "use strict";
 
 const yargs = require("yargs");
+const _ = require("lodash");
 
-module.exports = () =>
+module.exports = presets =>
   yargs
     .scriptName("oasis")
     .env("OASIS")
@@ -12,33 +13,33 @@ module.exports = () =>
     .options("open", {
       describe:
         "Automatically open app in web browser. Use --no-open to disable.",
-      default: true,
+      default: _.get(presets, "open", true),
       type: "boolean"
     })
     .options("offline", {
       describe:
         "Don't try to connect to scuttlebutt peers or pubs. This can be changed on the 'settings' page while Oasis is running.",
-      default: false,
+      default: _.get(presets, "offline", false),
       type: "boolean"
     })
     .options("host", {
       describe: "Hostname for web app to listen on",
-      default: "localhost",
+      default: _.get(presets, "host", "localhost"),
       type: "string"
     })
     .options("port", {
       describe: "Port for web app to listen on",
-      default: 3000,
+      default: _.get(presets, "port", 3000),
       type: "number"
     })
     .options("public", {
       describe:
         "Assume Oasis is being hosted publicly, disable HTTP POST and redact messages from people who haven't given consent for public web hosting.",
-      default: false,
+      default: _.get(presets, "public", false),
       type: "boolean"
     })
     .options("debug", {
       describe: "Use verbose output for debugging",
-      default: false,
+      default: _.get(presets, "debug", false),
       type: "boolean"
     }).argv;

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,24 @@
 
 // Koa application to provide HTTP interface.
 
+const fs = require("fs");
+const envPaths = require("env-paths");
+const config_file = envPaths("oasis", { suffix: "" }).config + "/config.json";
+console.log(`Trying to read config file ${config_file}`);
+var presets;
+if (fs.existsSync(config_file)) {
+  presets = require(config_file);
+} else {
+  presets = {};
+}
 const cli = require("./cli");
-const config = cli();
+const config = cli(presets);
 
 if (config.debug) {
   process.env.DEBUG = "oasis,oasis:*";
 }
+
+console.log(JSON.parse(JSON.stringify(config)));
 
 process.on("uncaughtException", function(err) {
   // This isn't `err.code` because TypeScript doesn't like that.
@@ -22,6 +34,8 @@ It might be another copy of Oasis or another program on your computer.
 You can run Oasis on a different port number with this option:
 
     oasis --port ${config.port + 1}
+
+Or you can set a default port in ${config_file}
 `
     );
   } else {
@@ -40,7 +54,6 @@ process.argv = [];
 const http = require("./http");
 
 const debug = require("debug")("oasis");
-const fs = require("fs").promises;
 const koaBody = require("koa-body");
 const { nav, ul, li, a } = require("hyperaxe");
 const open = require("open");
@@ -99,11 +112,11 @@ const defaultTheme = "atelier-sulphurPool-light".toLowerCase();
 const readmePath = path.join(__dirname, "..", "README.md");
 const packagePath = path.join(__dirname, "..", "package.json");
 
-fs.readFile(readmePath, "utf8").then(text => {
+fs.promises.readFile(readmePath, "utf8").then(text => {
   config.readme = text;
 });
 
-fs.readFile(packagePath, "utf8").then(text => {
+fs.promises.readFile(packagePath, "utf8").then(text => {
   config.version = JSON.parse(text).version;
 });
 


### PR DESCRIPTION
This should give pretty much expected behaviour. Each config value
can be set by three sources:

1. By command-line argument. If it is not given, then
2. By config file. Or, lastly
3. By default value in the source code.

I can't test that the config file is searched and read from the right
place on windows or macOS, but on linux it works.

**What's the problem you solved?**

**What solution are you recommending?**
