### PR TITLE
Add config documentation (addresses #254).

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,37 @@ Options:
   --host      Hostname for web app to listen on  [string] [default: "localhost"]
   --port      Port for web app to listen on             [number] [default: 3000]
   --debug     Use verbose output for debugging        [boolean] [default: false]
+  -c --config Show current default configuration      [boolean] [default: false]
 ```
+
+## Configuration
+
+The above options can be permanently set with a configuration file found in a
+standard folder for configuration, depending on your operating system:
+
+- Linux: `$XDG_CONFIG_HOME/oasis/default.json`.
+  Usually this is `/home/<your username>/.config/oasis/default.json`
+  <!-- cspell:disable-next-line -->
+- Windows `%APPDATA%\oasis\default.json`.
+- Mac OS, `<Library>/Preferences/oasis/default.json`
+
+The configuration file can override any or all of the command-line _defaults_.
+Here is an example customizing the port number and the "open" settings:
+
+```json
+{
+  "open": false,
+  "port": 19192
+}
+```
+
+### Configuration Semantics
+
+Which value is given is decided like this:
+
+1. If an argument is given on the command-line, use that value.
+2. Otherwise, use the value from the configuration file if present.
+3. If neither command-line nor configuration file are given, use the built-in default value.
 
 ## Installation
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@
 const yargs = require("yargs");
 const _ = require("lodash");
 
-module.exports = presets =>
+module.exports = (presets, defaultConfigFile) =>
   yargs
     .scriptName("oasis")
     .env("OASIS")
@@ -42,4 +42,5 @@ module.exports = presets =>
       describe: "Use verbose output for debugging",
       default: _.get(presets, "debug", false),
       type: "boolean"
-    }).argv;
+    })
+    .epilog(`The defaults can be configured in ${defaultConfigFile}.`).argv;

--- a/src/index.js
+++ b/src/index.js
@@ -14,15 +14,17 @@ const defaultConfigFile = path.join(
 );
 
 const defaultConfig = {};
+var haveConfig;
 
 try {
   const defaultConfigOverride = fs.readFileSync(defaultConfigFile, "utf8");
   Object.entries(JSON.parse(defaultConfigOverride)).forEach(([key, value]) => {
     defaultConfig[key] = value;
   });
+  haveConfig = true;
 } catch (e) {
   if (e.code === "ENOENT") {
-    // No default config, no problem.
+    haveConfig = false;
   } else {
     console.log(`There was a problem loading ${defaultConfigFile}`);
     throw e;
@@ -30,7 +32,26 @@ try {
 }
 
 const cli = require("./cli");
-const config = cli(defaultConfig);
+const config = cli(defaultConfig, defaultConfigFile);
+delete config._;
+delete config.$0;
+
+console.log();
+if (haveConfig) {
+  console.log(`Configuration read defaults from ${defaultConfigFile}`);
+} else {
+  console.log(
+    `No configuration file found at ${defaultConfigFile}. ` +
+      "Using built-in default values."
+  );
+}
+console.log("Current configuration:");
+console.log();
+console.log(JSON.stringify(config, null, 2));
+console.log();
+console.log(`Note: You can save the above to ${defaultConfigFile} to make \
+these settings the default. See the readme for details.`);
+console.log();
 
 if (config.debug) {
   process.env.DEBUG = "oasis,oasis:*";


### PR DESCRIPTION
**What's the problem you solved?**

Lack of documentation of how/where configuration is stored.

**What solution are you recommending?**

As @cinnamon-bun suggested...

* I added a few lines to the readme, 
* added a few lines to the `--help` text, and also 
* added output of current configuration location and values.

Had to coerce c-spell into ignoring the unknown word "APPDATA" and even though `prettylint` didn't complain, prettier did (but didn't say what's wrong) so I bypassed the pre-commit hook on this one.

More importantly though: I'm not 100% certain about the config location on Mac OS and Windows, I went with the `env-paths` docs on that one. So if someone could verify that would be cool. 

Good night :)