### PR TITLE
Fix queries with an unused `{index: "DTA"}` option

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -627,6 +627,7 @@ module.exports = ({ cooler, isPublic }) => {
           $filter: {
             value: {
               author: feed,
+              timestamp: { $lte: Date.now() },
               content: {
                 type: "vote"
               }
@@ -638,7 +639,6 @@ module.exports = ({ cooler, isPublic }) => {
       const options = configure(
         {
           query,
-          index: "DTA",
           reverse: true
         },
         customOptions
@@ -717,14 +717,14 @@ module.exports = ({ cooler, isPublic }) => {
             {
               $filter: {
                 value: {
+                  timestamp: { $lte: Date.now() },
                   content: {
                     type: "post"
                   }
                 }
               }
             }
-          ],
-          index: "DTA"
+          ]
         })
       );
       const followingFilter = await socialFilter({ following: true });
@@ -758,14 +758,14 @@ module.exports = ({ cooler, isPublic }) => {
             {
               $filter: {
                 value: {
+                  timestamp: { $lte: Date.now },
                   content: {
                     type: "post"
                   }
                 }
               }
             }
-          ],
-          index: "DTA"
+          ]
         })
       );
 
@@ -803,14 +803,14 @@ module.exports = ({ cooler, isPublic }) => {
             {
               $filter: {
                 value: {
+                  timestamp: { $lte: Date.now() },
                   content: {
                     type: "post"
                   }
                 }
               }
             }
-          ],
-          index: "DTA"
+          ]
         })
       );
 
@@ -915,12 +915,10 @@ module.exports = ({ cooler, isPublic }) => {
                   content: {
                     type: "vote"
                   }
-                },
-                timestamp: { $gte: earliest }
+                }
               }
             }
-          ],
-          index: "DTA"
+          ]
         })
       );
       const followingFilter = await socialFilter({ following: true });


### PR DESCRIPTION
Problem: Trying to use the DTA index when using SSB-Query doesn't work,
because that index only exists on SSB-Backlinks.

Solution: Change the filter to ensure that we're sorted by the asserted
timestamp and ignoring messages from the future. The SSB-Backlinks
plugin was taking the minimum between `.value.timestamp` and `timestamp`
but since we're not using SSB-Backlinks in this query (or maybe at all?)
we get to make our own little hacky query. Cel taught me that the
`$sort` option causes problems here because it buffers the entire result
in memory before doing the sort. Boo. Instead we just need to reference
the property that we want to be sorted by with some operation, even if
it does nothing (like `{ $gt: null }`), but since we're filtering time
travelers we actually need `{ $lge: Date.now() }` there anyway.