### PR TITLE
Add profile edit page

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -144,10 +144,11 @@ input {
   color: var(--fg);
   border: var(--pico) solid var(--bg-selection);
   padding: var(--milli);
-  margin-right: var(--whole);
+  margin: var(--whole) 0;
   -moz-appearance: none;
   appearance: none;
   border-radius: var(--common-radius);
+  display: block;
 }
 
 .contentWarning {

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,7 @@ const { about, blob, friend, meta, post, vote } = require("./models")({
 const {
   authorView,
   commentView,
+  editProfileView,
   extendedView,
   latestView,
   likesView,
@@ -295,27 +296,44 @@ router
     ctx.body = requireStyle(filePath);
   })
   .get("/profile/", async ctx => {
-    const profile = async () => {
-      const myFeedId = await meta.myFeedId();
+    const myFeedId = await meta.myFeedId();
 
-      const description = await about.description(myFeedId);
-      const name = await about.name(myFeedId);
-      const image = await about.image(myFeedId);
+    const description = await about.description(myFeedId);
+    const name = await about.name(myFeedId);
+    const image = await about.image(myFeedId);
 
-      const messages = await post.fromPublicFeed(myFeedId);
+    const messages = await post.fromPublicFeed(myFeedId);
 
-      const avatarUrl = `/image/256/${encodeURIComponent(image)}`;
+    const avatarUrl = `/image/256/${encodeURIComponent(image)}`;
 
-      return authorView({
-        feedId: myFeedId,
-        messages,
-        name,
-        description,
-        avatarUrl,
-        relationship: null
-      });
-    };
-    ctx.body = await profile();
+    ctx.body = await authorView({
+      feedId: myFeedId,
+      messages,
+      name,
+      description,
+      avatarUrl,
+      relationship: null
+    });
+  })
+  .get("/profile/edit", async ctx => {
+    const myFeedId = await meta.myFeedId();
+    const description = await about.description(myFeedId);
+    const name = await about.name(myFeedId);
+
+    ctx.body = await editProfileView({
+      name,
+      description
+    });
+  })
+  .post("/profile/edit", koaBody(), async ctx => {
+    const name = String(ctx.request.body.name);
+    const description = String(ctx.request.body.description);
+
+    ctx.body = await post.publishProfileEdit({
+      name,
+      description
+    });
+    ctx.redirect("/profile");
   })
   .get("/publish/custom/", async ctx => {
     ctx.body = await publishCustomView();

--- a/src/models.js
+++ b/src/models.js
@@ -1240,6 +1240,13 @@ module.exports = ({ cooler, isPublic }) => {
       debug("Published: %O", body);
       return ssb.publish(body);
     },
+    publishProfileEdit: async ({ name, description }) => {
+      const ssb = await cooler.open();
+      const body = { type: "about", about: ssb.id, name, description };
+
+      debug("Published: %O", body);
+      return ssb.publish(body);
+    },
     publishCustom: async options => {
       const ssb = await cooler.open();
       debug("Published: %O", options);

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -157,7 +157,12 @@ module.exports = {
     mysteryDescription: "posted a mysterious message",
     // misc
     oasisDescription: "Friendly neighborhood scuttlebutt interface",
-    submit: "Submit"
+    submit: "Submit",
+    editProfile: "Edit profile",
+    editProfileDescription:
+      "Edit your profile with Markdown. Messages cannot be edited or deleted. Old versions of your profile information still exist and are public information, but most SSB apps don't show it.",
+    profileName: "Profile name (text)",
+    profileDescription: "Profile description (Markdown)"
   },
   /* spell-checker: disable */
   es: {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -466,6 +466,37 @@ const post = ({ msg, aside = false }) => {
   }
 };
 
+exports.editProfileView = ({ name, description }) =>
+  template(
+    section(
+      h1(i18n.editProfile),
+      p(i18n.editProfileDescription),
+      form(
+        { action: "/profile/edit", method: "POST" },
+        label(
+          i18n.profileName,
+          input({ name: "name", autofocus: true, value: name })
+        ),
+        label(
+          i18n.profileDescription,
+          textarea(
+            {
+              autofocus: true,
+              name: "description"
+            },
+            description
+          )
+        ),
+        button(
+          {
+            type: "submit"
+          },
+          i18n.submit
+        )
+      )
+    )
+  );
+
 exports.authorView = ({
   avatarUrl,
   description,
@@ -543,7 +574,10 @@ exports.authorView = ({
     footer(
       a({ href: `/likes/${encodeURIComponent(feedId)}` }, i18n.viewLikes),
       span(relationshipText),
-      contactForm
+      contactForm,
+      relationship === null
+        ? a({ href: `/profile/edit` }, i18n.editProfile)
+        : null
     )
   );
 
@@ -672,17 +706,18 @@ exports.publishView = () => {
       form(
         { action: publishForm, method: "post" },
         label(
-          { for: "text" },
-          i18n.publishLabel({ markdownUrl, linkTarget: "_blank" })
+          i18n.publishLabel({ markdownUrl, linkTarget: "_blank" }),
+          textarea({ required: true, name: "text" })
         ),
-        textarea({ required: true, name: "text" }),
-        label({ for: "contentWarning" }, i18n.contentWarningLabel),
-        input({
-          name: "contentWarning",
-          type: "text",
-          class: "contentWarning",
-          placeholder: "Optional warning for the post"
-        }),
+        label(
+          i18n.contentWarningLabel,
+          input({
+            name: "contentWarning",
+            type: "text",
+            class: "contentWarning",
+            placeholder: "Optional warning for the post"
+          })
+        ),
         button({ type: "submit" }, i18n.submit)
       )
     ),
@@ -696,7 +731,7 @@ exports.settingsView = ({ status, peers, theme, themeNames, version }) => {
   const progressElements = Object.entries(status.sync.plugins).map(e => {
     const [key, val] = e;
     const id = `progress-${key}`;
-    return div(label({ for: id }, key), progress({ id, value: val, max }, val));
+    return div(label(key, progress({ id, value: val, max }, val)));
   });
 
   const startButton = form(
@@ -962,8 +997,7 @@ exports.searchView = ({ messages, query }) => {
       h1(i18n.search),
       form(
         { action: "/search", method: "get" },
-        label({ for: "query" }, i18n.searchLabel),
-        searchInput,
+        label(i18n.searchLabel, searchInput),
         button(
           {
             type: "submit"


### PR DESCRIPTION
Problem: An SSB client should allow you to declare your own name, but
Oasis didn't support that behavior at all.

Solution: Add a basic 'Edit Profile' page that lets you set your name
and description. This doesn't implement profile images because I had
limited time and didn't want to think about encoding formats, but it's
worth mentioning that I remember something about binary uploads with the
default form encoding actually send 3 times as much data because of
escapes or something? This might not effect us because we're on
localhost, but I want to make a note that this isn't implemented yet.

This also makes a small change regarding the `<label>` element --
previously we were writing them as siblings to the input and using the
`for` attribute to target the input, but while messing with the CSS I
tried putting them directly in the `label()` and it ends up having the
same effect with less code.