### PR TITLE
Hide search results from blocked feeds

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -684,10 +684,12 @@ module.exports = ({ cooler, isPublic }) => {
       });
 
       const source = await ssb.search.query(options);
+      const basicSocialFilter = await socialFilter();
 
       const messages = await new Promise((resolve, reject) => {
         pull(
           source,
+          basicSocialFilter,
           pull.filter(
             (
               message // avoid private messages (!)


### PR DESCRIPTION
Problem: The search results weren't hiding results from blocked feeds.

Solution: Add `socialFilter()` to ensure that all blocked feeds are
removed from search results as the first step in the stream processing.