### PR TITLE
Add hashtag support to search

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,8 @@ const {
   extendedView,
   latestView,
   likesView,
-  listView,
+  threadView,
+  hashtagView,
   markdownView,
   mentionsView,
   popularView,
@@ -263,6 +264,10 @@ router
     if (typeof query === "string") {
       // https://github.com/ssbc/ssb-search/issues/7
       query = query.toLowerCase();
+      if (query.length > 1 && query.startsWith("#")) {
+        const hashtag = query.slice(1);
+        return ctx.redirect(`/hashtag/${encodeURIComponent(hashtag)}`);
+      }
     }
 
     const messages = await post.search({ query });
@@ -277,14 +282,11 @@ router
     };
     ctx.body = await inbox();
   })
-  .get("/hashtag/:channel", async ctx => {
-    const { channel } = ctx.params;
-    const hashtag = async channel => {
-      const messages = await post.fromHashtag(channel);
+  .get("/hashtag/:hashtag", async ctx => {
+    const { hashtag } = ctx.params;
+    const messages = await post.fromHashtag(hashtag);
 
-      return listView({ messages });
-    };
-    ctx.body = await hashtag(channel);
+    ctx.body = await hashtagView({ hashtag, messages });
   })
   .get("/theme.css", ctx => {
     const theme = ctx.cookies.get("theme") || defaultTheme;
@@ -502,7 +504,7 @@ router
       const messages = await post.fromThread(message);
       debug("got %i messages", messages.length);
 
-      return listView({ messages });
+      return threadView({ messages });
     };
 
     ctx.body = await thread(message);

--- a/src/models.js
+++ b/src/models.js
@@ -923,7 +923,7 @@ module.exports = ({ cooler, isPublic }) => {
           index: "DTA"
         })
       );
-      const followingFilter = await socialFilter({ following: true });
+      const basicSocialFilter = await socialFilter();
 
       const messages = await new Promise((resolve, reject) => {
         pull(
@@ -998,12 +998,14 @@ module.exports = ({ cooler, isPublic }) => {
                     cb(null, null);
                   }
                 }),
+                // avoid private messages (!) and non-posts
                 pull.filter(
-                  (
-                    message // avoid private messages (!)
-                  ) => message && typeof message.value.content !== "string"
+                  message =>
+                    message &&
+                    typeof message.value.content !== "string" &&
+                    message.value.content.type === "post"
                 ),
-                followingFilter,
+                basicSocialFilter,
                 pull.collect((err, collectedMessages) => {
                   if (err) {
                     reject(err);

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -11,7 +11,7 @@ module.exports = {
     ],
     popular: "Popular",
     popularDescription: [
-      "Posts from people you follow, sorted by ",
+      "Posts from people in your network, sorted by ",
       strong("hearts"),
       " in a given period. Hearts are counted from ",
       em("everyone"),
@@ -157,7 +157,14 @@ module.exports = {
     mysteryDescription: "posted a mysterious message",
     // misc
     oasisDescription: "Friendly neighborhood scuttlebutt interface",
-    submit: "Submit"
+    submit: "Submit",
+    editProfile: "Edit profile",
+    editProfileDescription:
+      "Edit your profile with Markdown. Messages cannot be edited or deleted. Old versions of your profile information still exist and are public information, but most SSB apps don't show it.",
+    profileName: "Profile name (text)",
+    profileDescription: "Profile description (Markdown)",
+    hashtagDescription:
+      "Posts from people in your network that reference this hashtag, sorted by recency."
   },
   /* spell-checker: disable */
   es: {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -654,7 +654,7 @@ exports.publishCustomView = async () => {
   );
 };
 
-exports.listView = ({ messages }) =>
+exports.threadView = ({ messages }) =>
   template(messages.map(msg => post({ msg })));
 
 exports.markdownView = ({ text }) => {
@@ -972,6 +972,13 @@ exports.searchView = ({ messages, query }) => {
         )
       )
     ),
+    messages.map(msg => post({ msg }))
+  );
+};
+
+exports.hashtagView = ({ messages, hashtag }) => {
+  return template(
+    section(h1(`#${hashtag}`), p(i18n.hashtagDescription)),
     messages.map(msg => post({ msg }))
   );
 };


### PR DESCRIPTION
Problem: Searching for a hashtag should bring you to the hashtag page,
and the hashtag page should have some useful information about which
page you're on instead of just showing you the messages.

Solution: Add code so that if you search for a hashtag you're brought to
that page, and display some useful help text at the top of the page
explaining the hashtag page. While ensuring that the hashtag page showed
posts from around the network (instead of only people you're following)
I fixed the popular page so that it has the same behavior again (fixing
a regression) and filtered out gatherings (fixing *another* regression)
on the popular page. These probably should've happened in another commit
but I got carried away. :/

Happy to split this commit into two if it hurts to bundle the popular
fixes with the hashtag fix, but I'm low on energy and want to at least
open a PR in case it doesn't bother anyone.