### PR TITLE
Fix Extended page sorting posts incorrectly

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -760,7 +760,7 @@ module.exports = ({ cooler, isPublic }) => {
             {
               $filter: {
                 value: {
-                  timestamp: { $lte: Date.now },
+                  timestamp: { $lte: Date.now() },
                   content: {
                     type: "post"
                   }


### PR DESCRIPTION
Problem: The Extended page is sorting by received timestamp, not
asserted timestamp.

Solution: Find the `Date.now` and replace it with `Date.now()`, which
refers to the current date instead of `undefined`, which is what you get
if you try to `JSON.stringify(Date.now)`.