### PR TITLE
Show channel as text appended to posts

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -465,6 +465,13 @@ module.exports = ({ cooler, isPublic }) => {
           }
         }
 
+        const channel = lodash.get(msg, "value.content.channel");
+        const hasChannel = typeof channel === "string" && channel.length > 2;
+
+        if (hasChannel) {
+          msg.value.content.text += `\n\n#${channel}`;
+        }
+
         const avatarId =
           avatarMsg != null && typeof avatarMsg.link === "string"
             ? avatarMsg.link || nullImage


### PR DESCRIPTION
Problem: Other clients render a `channel` property, which is basically a
way to add a single hashtag to your post, but Oasis doesn't support
that. This means that someone might post "this is fun!" under the
channel #running and people using Oasis would just see "this is fun!"
without any context.

Solution: Add the hashtag to the bottom of the post, which visually
looks the same as someone adding two newlines and a hashtag to the end
of the text in their post.