### PR TITLE
Simplify installation

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -3,6 +3,7 @@
   "language": "en",
   "words": [
     "AGPL",
+    "EACCESS",
     "Argyris",
     "Hintjens",
     "Kata",

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ Most people should install stable releases with [npm](https://npmjs.org/) and
 Node.js [**current** or **active LTS** release](https://nodejs.org/en/about/releases/).
 
 ```shell
-npm --global install 'fraction/oasis#semver:*'
+npm -g install fraction/oasis#semver:
 ```
 
 For faster updates and less stability, install from GitHub and upgrade often.
 
 ```shell
-npm --global install fraction/oasis
+npm -g install fraction/oasis
 ```
 
 Want more? Check out [`install.md`](https://github.com/fraction/oasis/blob/master/docs/install.md).

--- a/README.md
+++ b/README.md
@@ -18,58 +18,16 @@ No browser JavaScript! Oasis has strict security rules that prevent any
 JavaScript from running in your browser, which helps us make Oasis accessible
 and easy to improve.
 
+## Example
+
+```sh
+oasis
+```
+
 ![Screenshot of Oasis](./docs/screenshot.png)
 
-## Usage
-
-Start Oasis from a command-line interface with the `oasis` command.
-
-```console
-$ oasis --help
-Usage: oasis [options]
-
-Options:
-  --version   Show version number                                      [boolean]
-  -h, --help  Show help                                                [boolean]
-  --open      Automatically open app in web browser. Use --no-open to disable.
-                                                       [boolean] [default: true]
-  --offline   Don't try to connect to scuttlebutt peers or pubs. This can be
-              changed on the 'settings' page while Oasis is running.
-                                                      [boolean] [default: false]
-  --host      Hostname for web app to listen on  [string] [default: "localhost"]
-  --port      Port for web app to listen on             [number] [default: 3000]
-  --debug     Use verbose output for debugging        [boolean] [default: false]
-  -c --config Show current default configuration      [boolean] [default: false]
-```
-
-## Configuration
-
-The above options can be permanently set with a configuration file found in a
-standard folder for configuration, depending on your operating system:
-
-- Linux: `$XDG_CONFIG_HOME/oasis/default.json`.
-  Usually this is `/home/<your username>/.config/oasis/default.json`
-  <!-- cspell:disable-next-line -->
-- Windows `%APPDATA%\oasis\default.json`.
-- Mac OS, `/Users/<your username>/Library/Preferences/oasis/default.json`
-
-The configuration file can override any or all of the command-line _defaults_.
-Here is an example customizing the port number and the "open" settings:
-
-```json
-{
-  "open": false,
-  "port": 19192
-}
-```
-
-### Configuration Semantics
-
-Which value is given is decided like this:
-
-1. If an argument is given on the command-line, use that value.
-2. Otherwise, use the value from the configuration file if present.
-3. If neither command-line nor configuration file are given, use the built-in default value.
+Use `oasis --help` to get configuration options. You can change the default
+values with a custom [configuration](./docs/configuring.md).
 
 ## Installation
 
@@ -86,7 +44,8 @@ For faster updates and less stability, install from GitHub and upgrade often.
 npm -g install fraction/oasis
 ```
 
-Want more? Check out [`install.md`](https://github.com/fraction/oasis/blob/master/docs/install.md).
+Check out [`install.md`](https://github.com/fraction/oasis/blob/master/docs/install.md)
+for more information.
 
 ## Resources
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1,0 +1,28 @@
+# Configuring
+
+The default options can be permanently set with a configuration file found in a
+standard folder for configuration, depending on your operating system:
+
+- Linux: `$XDG_CONFIG_HOME/oasis/default.json`.
+  Usually this is `/home/<your username>/.config/oasis/default.json`
+  <!-- cspell:disable-next-line -->
+- Windows `%APPDATA%\oasis\default.json`.
+- Mac OS, `/Users/<your username>/Library/Preferences/oasis/default.json`
+
+The configuration file can override any or all of the command-line _defaults_.
+Here is an example customizing the port number and the "open" settings:
+
+```json
+{
+  "open": false,
+  "port": 19192
+}
+```
+
+## Semantics
+
+Which value is given is decided like this:
+
+1. If an argument is given on the command-line, use that value.
+2. Otherwise, use the value from the configuration file if present.
+3. If neither command-line nor configuration file are given, use the built-in default value.

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,40 +12,35 @@ If you want to run Oasis on Android via Termux, see [`with-termux.md`](./with-te
 
 ## Download
 
-### HTTPS
-
-Most people should download Oasis over HTTPS.
+Download Oasis from GitHub over HTTPS.
 
 ```shell
 git clone https://github.com/fraction/oasis.git
 ```
 
-### SSH
-
-If you already have SSH, you may prefer to download over SSH instead.
-
-```shell
-git clone git@github.com:fraction/oasis.git
-```
-
-## Install
+## Install dependencies
 
 Most people should build and install Oasis with npm.
 
 ```shell
 cd oasis
-npm install
-npm --global install .
+npm install --only=prod
 ```
 
 ## Start
 
-You did it! Oasis should now be installed.
+You can try Oasis without installing with:
 
 ```shell
-oasis --help
+node .
 ```
 
-If you have problems, read the documentation on [downloading and installing
-packages globally](https://docs.npmjs.com/downloading-and-installing-packages-globally)
-or [get some help](https://github.com/fraction/oasis/issues/new/choose).
+## Install globally
+
+If you want to install to make `oasis` available globally:
+
+```shell
+npm -g install .
+```
+
+If you see a permission error, see [resolving EACCESS permission errors](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally). If you any other problems, please [reach out for help](https://github.com/fraction/oasis/issues/new).


### PR DESCRIPTION
Problem: The install instructions in the readme contains quotes because
it has a `*`, but `#semver:` does what we need without the quotes. The
`docs/install.md` file also has some unnecessary complexity, like
cloning via SSH (only useful for maintainers), which I think we can
safely remove.

Solution: Change the install instruction and reorganize
`docs/install.md` to be more relevant to people who are installing from
source.