### PR TITLE
Add profile image upload

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -21,6 +21,8 @@
     "libsodium",
     "libtool",
     "manyverse",
+    "mebibyte",
+    "mebibytes",
     "minlength",
     "mkdir",
     "monokai",

--- a/src/index.js
+++ b/src/index.js
@@ -362,13 +362,15 @@ router
       description
     });
   })
-  .post("/profile/edit", koaBody(), async ctx => {
+  .post("/profile/edit", koaBody({ multipart: true }), async ctx => {
     const name = String(ctx.request.body.name);
     const description = String(ctx.request.body.description);
 
+    const image = await fs.promises.readFile(ctx.request.files.image.path);
     ctx.body = await post.publishProfileEdit({
       name,
-      description
+      description,
+      image
     });
     ctx.redirect("/profile");
   })

--- a/src/models.js
+++ b/src/models.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const debug = require("debug")("oasis");
-debug.enabled = true;
 const { isRoot, isReply } = require("ssb-thread-schema");
 const lodash = require("lodash");
 const prettyMs = require("pretty-ms");
@@ -9,6 +8,7 @@ const pullParallelMap = require("pull-paramap");
 const pull = require("pull-stream");
 const pullSort = require("pull-sort");
 const ssbRef = require("ssb-ref");
+const crypto = require("crypto");
 
 // HACK: https://github.com/ssbc/ssb-thread-schema/issues/4
 const isNestedReply = require("ssb-thread-schema/post/nested-reply/validator");
@@ -1253,7 +1253,6 @@ module.exports = ({ cooler, isPublic }) => {
     publishProfileEdit: async ({ name, description, image }) => {
       const ssb = await cooler.open();
       if (image.length > 0) {
-        console.log("have img");
         // 5 MiB check
         const mebibyte = Math.pow(2, 20);
         const maxSize = 5 * mebibyte;
@@ -1261,7 +1260,7 @@ module.exports = ({ cooler, isPublic }) => {
           throw new Error("Image file is too big, maximum size is 5 mebibytes");
         }
         const algorithm = "sha256";
-        const hash = require("crypto")
+        const hash = crypto
           .createHash(algorithm)
           .update(image)
           .digest("base64");
@@ -1288,7 +1287,6 @@ module.exports = ({ cooler, isPublic }) => {
           );
         });
       } else {
-        console.log("no img");
         const body = { type: "about", about: ssb.id, name, description };
         debug("Published: %O", body);
         return ssb.publish(body);

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -162,6 +162,7 @@ module.exports = {
     editProfileDescription:
       "Edit your profile with Markdown. Messages cannot be edited or deleted. Old versions of your profile information still exist and are public information, but most SSB apps don't show it.",
     profileName: "Profile name (text)",
+    profileImage: "Profile image",
     profileDescription: "Profile description (Markdown)",
     hashtagDescription:
       "Posts from people in your network that reference this hashtag, sorted by recency."

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -472,11 +472,16 @@ exports.editProfileView = ({ name, description }) =>
       h1(i18n.editProfile),
       p(i18n.editProfileDescription),
       form(
-        { action: "/profile/edit", method: "POST" },
+        {
+          action: "/profile/edit",
+          method: "POST",
+          enctype: "multipart/form-data"
+        },
         label(
-          i18n.profileName,
-          input({ name: "name", autofocus: true, value: name })
+          i18n.profileImage,
+          input({ type: "file", name: "image", accept: "image/*" })
         ),
+        label(i18n.profileName, input({ name: "name", value: name })),
         label(
           i18n.profileDescription,
           textarea(


### PR DESCRIPTION
Problem: We can set our name and profile description but profile images
are expected by most people and supported by most clients and we don't
have them. A profile without an image can sometimes lack the intimacy
you'd get if you let people upload profile images that they can use as a
visual avatar.

Solution: Add profile image upload to the Edit Profile page and add a
bunch of plumbing for `ssb.blobs.add()` to add the blob and publish a
message setting it as a profile image.