### PR TITLE
Fixed wrapping in README to improve readability of /settings/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,18 @@
 # Oasis
 
-Oasis is a **free, open-source, peer-to-peer social application** that helps
-you follow friends and discover new ones on [Secure Scuttlebutt (SSB)][ssb].
+Oasis is a **free, open-source, peer-to-peer social application** that helps you follow friends and discover new ones on [Secure Scuttlebutt (SSB)][ssb].
 
-**🦀 Powered by SSB.**  
-You're the center of your own distributed network. Online or offline, SSB works
-anywhere that you are. Follow the people you want to see and never worry about
-spam again. Migrate your data to another SSB app any time you want.
+### 🦀 Powered by SSB
 
-**🌐 Bring your own browser.**  
-Use your favorite web browser to read and write messages to the people you care
-about. Oasis runs a small HTTP server on your own computer, so you don't need
-to worry about adding another Electron app to your computer.
+You're the center of your own distributed network. Online or offline, SSB works anywhere that you are. Follow the people you want to see and never worry about spam again. Migrate your data to another SSB app any time you want.
 
-**🏰 Just HTML and CSS.**  
-No browser JavaScript! Oasis has strict security rules that prevent any
-JavaScript from running in your browser, which helps us make Oasis accessible
-and easy to improve.
+### 🌐 Bring your own browser
+
+Use your favorite web browser to read and write messages to the people you care about. Oasis runs a small HTTP server on your own computer, so you don't need to worry about adding another Electron app to your computer.
+
+### 🏰 Just HTML and CSS
+
+No browser JavaScript! Oasis has strict security rules that prevent any JavaScript from running in your browser, which helps us make Oasis accessible and easy to improve.
 
 ## Example
 
@@ -30,8 +26,7 @@ It will then pop open a browser window for you.
 
 ![Screenshot of Oasis](./docs/screenshot.png)
 
-Use `oasis --help` to get configuration options. You can change the default
-values with a custom [configuration](./docs/configuring.md).
+Use `oasis --help` to get configuration options. You can change the default values with a custom [configuration](./docs/configuring.md).
 
 ## Installation
 


### PR DESCRIPTION
## What's the problem you solved?
When viewing /settings/readme as linked in the setting page, there was some issues with the way README was formatted as you can see in this screenshot:

![Screenshot_2020-03-03 Oasis](https://user-images.githubusercontent.com/18296993/75830940-11a3ea80-5daa-11ea-8104-cf6a22933b9f.png)

## What solution are you recommending?
Tweak markdown so that it looks better in the browser:
![Screenshot_2020-03-03 Oasis(1)](https://user-images.githubusercontent.com/18296993/75830959-241e2400-5daa-11ea-8bdb-f4b8e43d58c9.png)
