### PR TITLE
Small text tweaks to /publish

### DIFF
--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -82,7 +82,7 @@ module.exports = {
       "."
     ],
     publishLabel: ({ markdownUrl, linkTarget }) => [
-      "Write a new public message in ",
+      "Write a new public post in ",
       a(
         {
           href: markdownUrl,
@@ -90,7 +90,7 @@ module.exports = {
         },
         "Markdown"
       ),
-      ". Messages cannot be edited or deleted."
+      ". Posts cannot be edited or deleted."
     ],
     publishCustomInfo: ({ href }) => [
       "If you're an advanced user, you can also ",

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -82,7 +82,7 @@ module.exports = {
       "."
     ],
     publishLabel: ({ markdownUrl, linkTarget }) => [
-      "Write a new message in ",
+      "Write a new public message in ",
       a(
         {
           href: markdownUrl,

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -715,7 +715,7 @@ exports.publishView = () => {
             name: "contentWarning",
             type: "text",
             class: "contentWarning",
-            placeholder: "Optional warning for the post"
+            placeholder: "Optional content warning for the post"
           })
         ),
         button({ type: "submit" }, i18n.submit)

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -715,7 +715,7 @@ exports.publishView = () => {
             name: "contentWarning",
             type: "text",
             class: "contentWarning",
-            placeholder: "Optional content warning for the post"
+            placeholder: "Optional content warning for this post"
           })
         ),
         button({ type: "submit" }, i18n.submit)


### PR DESCRIPTION
## What's the problem you solved?
Additional linguistic clarification for /publish. 

## What solution are you recommending?
Changed "message" to "post" and adding the word "content" to the content warning text.