### PR TITLE
Vanilla markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # Oasis
 
-Oasis is a **free, open-source, peer-to-peer social application** that helps you follow friends and discover new ones on [Secure Scuttlebutt (SSB)][ssb].
+Oasis is a **free, open-source, peer-to-peer social application** that helps
+you follow friends and discover new ones on [Secure Scuttlebutt (SSB)][ssb].
 
-### 🦀 Powered by SSB
+**🦀 Powered by SSB.**  
+You're the center of your own distributed network. Online or offline, SSB works
+anywhere that you are. Follow the people you want to see and never worry about
+spam again. Migrate your data to another SSB app any time you want.
 
-You're the center of your own distributed network. Online or offline, SSB works anywhere that you are. Follow the people you want to see and never worry about spam again. Migrate your data to another SSB app any time you want.
+**🌐 Bring your own browser.**  
+Use your favorite web browser to read and write messages to the people you care
+about. Oasis runs a small HTTP server on your own computer, so you don't need
+to worry about adding another Electron app to your computer.
 
-### 🌐 Bring your own browser
-
-Use your favorite web browser to read and write messages to the people you care about. Oasis runs a small HTTP server on your own computer, so you don't need to worry about adding another Electron app to your computer.
-
-### 🏰 Just HTML and CSS
-
-No browser JavaScript! Oasis has strict security rules that prevent any JavaScript from running in your browser, which helps us make Oasis accessible and easy to improve.
+**🏰 Just HTML and CSS.**  
+No browser JavaScript! Oasis has strict security rules that prevent any
+JavaScript from running in your browser, which helps us make Oasis accessible
+and easy to improve.
 
 ## Example
 
@@ -26,7 +30,8 @@ It will then pop open a browser window for you.
 
 ![Screenshot of Oasis](./docs/screenshot.png)
 
-Use `oasis --help` to get configuration options. You can change the default values with a custom [configuration](./docs/configuring.md).
+Use `oasis --help` to get configuration options. You can change the default
+values with a custom [configuration](./docs/configuring.md).
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "koa-router": "^7.4.0",
     "koa-static": "^5.0.0",
     "lodash": "^4.17.11",
+    "markdown-it": "^8.4.2",
     "open": "7.0.0",
     "pretty-ms": "^5.0.0",
     "pull-paramap": "^1.2.2",

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,8 +1,9 @@
 "use strict";
 
 const debug = require("debug")("oasis");
-const ssbMarkdown = require("ssb-markdown");
 const highlightJs = require("highlight.js");
+
+const MarkdownIt = require("markdown-it");
 
 const {
   a,
@@ -43,6 +44,8 @@ const {
 
 const lodash = require("lodash");
 const markdown = require("./markdown");
+
+const md = new MarkdownIt();
 
 const i18nBase = require("./i18n");
 let i18n = null;
@@ -692,7 +695,7 @@ exports.threadView = ({ messages }) =>
   template(messages.map(msg => post({ msg })));
 
 exports.markdownView = ({ text }) => {
-  const rawHtml = ssbMarkdown.block(text);
+  const rawHtml = md.render(text);
 
   return template(section({ class: "message" }, { innerHTML: rawHtml }));
 };


### PR DESCRIPTION
Problem: The SSB-Markdown library has some SSB-flavored quirks, like
messing with newline behavior, and is inappropriate for rendering plain
Markdown like the readme.

Solution: Since SSB-Markdown uses Markdown-It under the hood, we can use
the same library and just render our Markdown *without* the SSB-flavored
quirks. This gives us the ability to wrap text and avoid SSB-Markdown
problems without having to rewrite all of our Markdown.

cc: @georgeowell I think this also resolves the problem you described in #283 without rewriting any Markdown. :tada: