### PR TITLE
Small i18n improvements

### DIFF
--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -75,6 +75,8 @@ module.exports = {
       strong("reply"),
       " instead."
     ],
+    commentPublic: "public",
+    commentPrivate: "private",
     commentLabel: ({ publicOrPrivate, markdownUrl }) => [
       "Write a ",
       strong(`${publicOrPrivate} comment`),
@@ -249,6 +251,8 @@ module.exports = {
       strong("antworten"),
       " stattdessen."
     ],
+    commentPublic: "öffentlichen",
+    commentPrivate: "privaten",
     commentLabel: ({ publicOrPrivate, markdownUrl }) => [
       "Verfasse einen ",
       strong(`${publicOrPrivate} Kommentar`),

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -64,6 +64,7 @@ module.exports = {
     likedBy: "'s likes",
     // composer
     publish: "Publish",
+    contentWarningPlaceholder: "Optional content warning for this post",
     publishCustomDescription: [
       "Publish a custom message by entering ",
       a({ href: "https://en.wikipedia.org/wiki/JSON" }, "JSON"),
@@ -237,6 +238,7 @@ module.exports = {
     likedBy: "'s Likes",
     // composer
     publish: "Veröffentlichen",
+    contentWarningPlaceholder: "Optionale Inhaltswarnung für diesen Beitrag",
     publishCustomDescription: [
       "Veröffentliche eine benutzerdefinierte Nachricht durch das Eingeben von ",
       a({ href: "https://en.wikipedia.org/wiki/JSON" }, "JSON"),

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -613,7 +613,7 @@ exports.commentView = async ({ messages, myFeedId, parentMessage }) => {
 
   const isPrivate = parentMessage.value.meta.private;
 
-  const publicOrPrivate = isPrivate ? "private" : "public";
+  const publicOrPrivate = isPrivate ? i18n.commentPrivate : i18n.commentPublic;
   const maybeReplyText = isPrivate ? [null] : i18n.commentWarning;
 
   return template(

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -718,7 +718,7 @@ exports.publishView = () => {
             name: "contentWarning",
             type: "text",
             class: "contentWarning",
-            placeholder: "Optional content warning for this post"
+            placeholder: i18n.contentWarningPlaceholder
           })
         ),
         button({ type: "submit" }, i18n.submit)


### PR DESCRIPTION
## What's the problem you solved?

Some strings were still hardcoded and not translatable. Fixes #294 

## What solution are you recommending?

Added a i18n string for the contentWarningPlaceholder and for "private/public" adjectives when writing a comment.

## Questions

I am not super confident about my naming of the i18n strings, so I am open to other naming suggestions.
