### PR TITLE
Upgrade npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -183,17 +183,17 @@
       "integrity": "sha512-Lnle0J8t+Z+jFg78GFFnGo+Fphxaco9K9SppeBDsI27QBRBumxeGAMeOg5wt6XbAuj5pQWmAEWWEwPz4PYGMHw=="
     },
     "@fraction/flotilla": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@fraction/flotilla/-/flotilla-4.0.0.tgz",
-      "integrity": "sha512-n1CmZff4MfXexv6eX8HLojLBrVZa3zpkEndwtRYpjJMZIZPmX9belPFCeutzMupEY7D/0we2gsJ6C030h63zYA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@fraction/flotilla/-/flotilla-4.0.1.tgz",
+      "integrity": "sha512-ZSRHLVT79Z1OrGLvMm4LyDVw7x0puIS1s8VxExmeHZUVjlwZUwWgzeLZs3x82XQn7xtUIkU+aIrNs5gAHyLM5Q==",
       "requires": {
         "lodash.shuffle": "^4.2.0",
         "secret-stack": "^6.3.0",
         "ssb-about": "^2.0.1",
-        "ssb-backlinks": "^0.7.3",
+        "ssb-backlinks": "^1.0.0",
         "ssb-blobs": "^1.2.2",
-        "ssb-conn": "^0.15.2",
-        "ssb-db": "^19.3.0",
+        "ssb-conn": "^0.16.0",
+        "ssb-db": "^19.4.0",
         "ssb-ebt": "^5.6.7",
         "ssb-friends": "^4.1.4",
         "ssb-invite": "^2.1.3",
@@ -206,7 +206,7 @@
         "ssb-plugins": "^1.0.2",
         "ssb-query": "^2.4.3",
         "ssb-replicate": "^1.3.0",
-        "ssb-room": "^1.1.1",
+        "ssb-room": "^1.2.2",
         "ssb-search": "^1.2.1",
         "ssb-tangle": "^1.0.1",
         "ssb-unix-socket": "^1.0.0",
@@ -355,9 +355,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
     "acorn-jsx": {
       "version": "5.1.0",
@@ -3467,9 +3467,9 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-alphabetical": {
       "version": "1.0.4",
@@ -4129,9 +4129,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -4283,9 +4283,9 @@
       }
     },
     "leveldown": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.4.1.tgz",
-      "integrity": "sha512-3lMPc7eU3yj5g+qF1qlALInzIYnkySIosR1AsUKFjL9D8fYbTLuENBAeDRZXIG4qeWOAyqRItOoLu2v2avWiMA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.5.1.tgz",
+      "integrity": "sha512-GoC455/ncfg4yLLItr192HuXpA+CcQ2q9GncXJhewvvlpsBBEegChn5tMPP+kGvJt7u2LuXAd8fY2moQxFD+sQ==",
       "requires": {
         "abstract-leveldown": "~6.2.1",
         "napi-macros": "~2.0.0",
@@ -4852,9 +4852,9 @@
       "dev": true
     },
     "muxrpc": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.8.tgz",
-      "integrity": "sha512-9oLoLbiAWZAhgxQzquApj0eSfiTYPWLq4AV5mvCBjsicJKWOJlxAAxypHdlnmHeUbOxrPRweneHI7l+nzY/+aQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.5.0.tgz",
+      "integrity": "sha512-8kCo33LTYPYWAJGi2Ag2ukcluoNqJIe6Ay9QtGf7EXAUlTuMSA0HqR7jCbXt7DQPR4Alu/T3/mOguuERpDMGcw==",
       "requires": {
         "explain-error": "^1.0.1",
         "packet-stream": "~2.0.0",
@@ -5724,12 +5724,12 @@
       "integrity": "sha1-m0fiyyrkl+seutwsQZHWTRXJSdE="
     },
     "proxy-addr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.9.0"
+        "ipaddr.js": "1.9.1"
       }
     },
     "prr": {
@@ -6994,17 +6994,15 @@
       }
     },
     "ssb-backlinks": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-0.7.3.tgz",
-      "integrity": "sha512-84s5phSVyZsYV0FTmBJvICPgOMuu8ouzukG8Gz2XtuOui95GBP/G7UIBURgYVS82XA6g9xPA/jf38fsMxid38Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-1.0.0.tgz",
+      "integrity": "sha512-cgBfw+5oQMmFWX5czTHonZboZC9rRgZZlC2TwkSZvOZMWNxZKr98zvb56lRFiO4Et6DcEh3hXsyZyMyo6jN0WA==",
       "requires": {
         "base64-url": "^2.2.0",
-        "deep-equal": "^1.0.1",
         "flumeview-query": "^6.2.0",
         "pull-stream": "^3.6.7",
         "ssb-keys": "^7.0.14",
-        "ssb-ref": "^2.9.0",
-        "xtend": "^4.0.1"
+        "ssb-ref": "^2.9.0"
       }
     },
     "ssb-blobs": {
@@ -7042,18 +7040,6 @@
         "ssb-keys": "^7.2.1"
       },
       "dependencies": {
-        "muxrpc": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.5.0.tgz",
-          "integrity": "sha512-8kCo33LTYPYWAJGi2Ag2ukcluoNqJIe6Ay9QtGf7EXAUlTuMSA0HqR7jCbXt7DQPR4Alu/T3/mOguuERpDMGcw==",
-          "requires": {
-            "explain-error": "^1.0.1",
-            "packet-stream": "~2.0.0",
-            "packet-stream-codec": "^1.1.1",
-            "pull-goodbye": "0.0.2",
-            "pull-stream": "^3.6.10"
-          }
-        },
         "ssb-keys": {
           "version": "7.2.2",
           "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
@@ -7081,9 +7067,9 @@
       }
     },
     "ssb-conn": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-0.15.2.tgz",
-      "integrity": "sha512-QTdyOobC1ybnz0DHG1U0IrypRI9skd47HKXT6spQ2dnF8S4UQr29YOBWt4dWXfgnBP5a7WHMg07MY90XszwbGg==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-0.16.2.tgz",
+      "integrity": "sha512-KinjdF3tOMmlcjKK4bnTso0x6GYfL+9tE2gSacRDldaLui73nDLxSwjnSoE188wDXUEumJU0LvOff4AHm2XyLQ==",
       "requires": {
         "debug": "~4.1.1",
         "has-network2": "0.0.1",
@@ -7163,13 +7149,11 @@
       }
     },
     "ssb-db": {
-      "version": "19.3.2",
-      "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-19.3.2.tgz",
-      "integrity": "sha512-abbJ5Z9nMP6dHk0cLrTlDqsjJwVX3oiE+UaM0B5NYDIZtBUPM9M7cHt6kjI1COLHJA3+Pm7zDGeLax9okcADbw==",
+      "version": "19.4.0",
+      "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-19.4.0.tgz",
+      "integrity": "sha512-b6Q/UuGqxeyPAMJc2a/Q4clCR7UxTVIkrRw/6FEypn4p0LgWIOaqMdhyuJugzMb1k8dIEdlMdfEPq/FrTeLXkg==",
       "requires": {
         "async-write": "^2.1.0",
-        "cont": "~1.0.0",
-        "explain-error": "~1.0.1",
         "flumedb": "^1.1.0",
         "flumelog-offset": "^3.4.2",
         "flumeview-level": "^3.0.13",
@@ -7187,7 +7171,6 @@
         "ssb-msgs": "^5.0.0",
         "ssb-ref": "^2.12.0",
         "ssb-validate": "^4.0.0",
-        "typewiselite": "^1.0.0",
         "zerr": "^1.0.0"
       }
     },
@@ -7272,9 +7255,9 @@
       }
     },
     "ssb-markdown": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ssb-markdown/-/ssb-markdown-6.0.3.tgz",
-      "integrity": "sha512-pVOStAcoBzQ/KvV1OyE7yREuhi/qUd10gLbKcnldELBwniSovuia867s2F67dPfRr3ASLXjfm+Zz5dnPXE/jVw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ssb-markdown/-/ssb-markdown-6.0.4.tgz",
+      "integrity": "sha512-MdmHnev7259wzGcCSBo6A93kR/3iIx5sWrrzFTuyDmAAgHLycvotS6tbcge15AlPZDNRmo2N3MyHKTYb+SYbUA==",
       "requires": {
         "emoji-regex": "^8.0.0",
         "hashtag-regex": "^2.1.0",
@@ -7433,9 +7416,9 @@
       }
     },
     "ssb-room": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ssb-room/-/ssb-room-1.2.0.tgz",
-      "integrity": "sha512-WuBwYr5szFP9c7M1wk6WW/J+ByHB9MIpus4qVSFEes9NCmwStnLRJGeQZf6DnJe0M4rwddrwb6UUh4M/bApNNQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-room/-/ssb-room-1.2.2.tgz",
+      "integrity": "sha512-oPduyTzzGOeCs+wE77XjQfqNhNC3mOV98MS61cRRkXH2hGd6s+UM0KItQ0o10fcHZ4+32IeTDy7C66s2Dfyb3Q==",
       "requires": {
         "body-parser": "^1.16.0",
         "debug": "~4.1.1",
@@ -7566,9 +7549,9 @@
       }
     },
     "ssb-typescript": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ssb-typescript/-/ssb-typescript-1.5.0.tgz",
-      "integrity": "sha512-I4oe7BDYmk3kopVZC4BrXuKfugpJphLcZTmheofW2Dwanm6VutLfzLgz6juqt7aYKeIH5Ps3sJvZWQLw3MvUMQ=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ssb-typescript/-/ssb-typescript-1.7.0.tgz",
+      "integrity": "sha512-BuU8Buzm/TCA8WEUEX4mOO6AkgCPnrtoJQE7K4JY9eOvShEtA6qjvzKuNG4ZwivIwfGy+eF9fl5WFkaihqnj4A=="
     },
     "ssb-unix-socket": {
       "version": "1.0.0",
@@ -8060,9 +8043,9 @@
       }
     },
     "tape": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.0.tgz",
-      "integrity": "sha512-J/hvA+GJnuWJ0Sj8Z0dmu3JgMNU+MmusvkCT7+SN4/2TklW18FNCp/UuHIEhPZwHfy4sXfKYgC7kypKg4umbOw==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.2.tgz",
+      "integrity": "sha512-waWwC/OqYVE9TS6r1IynlP2sEdk4Lfo6jazlgkuNkPTHIbuG2BTABIaKdlQWwPeB6Oo4ksZ1j33Yt0NTOAlYMQ==",
       "requires": {
         "deep-equal": "~1.1.1",
         "defined": "~1.0.0",
@@ -8075,16 +8058,16 @@
         "is-regex": "~1.0.5",
         "minimist": "~1.2.0",
         "object-inspect": "~1.7.0",
-        "resolve": "~1.14.2",
+        "resolve": "~1.15.1",
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.2.1",
         "through": "~2.3.8"
       },
       "dependencies": {
         "resolve": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-          "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
           "requires": {
             "path-parse": "^1.0.6"
           }
@@ -8924,9 +8907,9 @@
       }
     },
     "yargs": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-      "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.0.tgz",
+      "integrity": "sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==",
       "requires": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -8938,9 +8921,14 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^16.1.0"
+        "yargs-parser": "^18.1.0"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -8985,6 +8973,15 @@
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.0"
           }
+        },
+        "yargs-parser": {
+          "version": "18.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.0.tgz",
+          "integrity": "sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
@@ -8992,6 +8989,7 @@
       "version": "16.1.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
       "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -9000,7 +8998,8 @@
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@fraction/base16-css": "^1.1.0",
-    "@fraction/flotilla": "^4.0.0",
+    "@fraction/flotilla": "^4.0.1",
     "debug": "^4.1.1",
     "env-paths": "^2.2.0",
     "highlight.js": "^9.18.1",
@@ -44,13 +44,13 @@
     "sharp": "^0.23.0",
     "ssb-client": "^4.9.0",
     "ssb-config": "^3.4.4",
-    "ssb-markdown": "^6.0.3",
+    "ssb-markdown": "^6.0.4",
     "ssb-mentions": "^0.5.2",
     "ssb-msgs": "^5.2.0",
     "ssb-ref": "^2.13.9",
     "ssb-tangle": "^1.0.1",
     "ssb-thread-schema": "^1.1.1",
-    "yargs": "^15.0.0"
+    "yargs": "^15.3.0"
   },
   "devDependencies": {
     "changelog-version": "^1.0.1",


### PR DESCRIPTION
Problem: Patchwork is soon going to release with a new SSB-Backlinks,
and since we share a database with Patchwork we should make sure we're
on the same version. If we're on different versions, we'll be constantly
regenerating indexes and that isn't fun for anyone.

Solution: Upgrade npm dependencies.
