### PR TITLE
Present error message while waiting for indexing

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -22,6 +22,7 @@
     "libsodium",
     "libtool",
     "manyverse",
+    "mebibyte",
     "minlength",
     "mkdir",
     "monokai",

--- a/src/http.js
+++ b/src/http.js
@@ -16,8 +16,8 @@ module.exports = ({ host, port, middleware }) => {
   app.on("error", err => {
     // Output full error objects
     err.message = err.stack;
-    err.expose = true;
     console.error(err);
+    err.expose = true;
     return null;
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -755,6 +755,30 @@ const middleware = [
     setLanguage(selectedLanguage);
     await next();
   },
+  async (ctx, next) => {
+    const ssb = await cooler.open();
+
+    const status = await ssb.status();
+    const values = Object.values(status.sync.plugins);
+    const totalCurrent = Object.values(status.sync.plugins).reduce(
+      (acc, cur) => acc + cur,
+      0
+    );
+    const totalTarget = status.sync.since * values.length;
+
+    const left = totalTarget - totalCurrent;
+
+    // Weird trick to get percentage with 1 decimal place (e.g. 78.9)
+    const percent = Math.floor((totalCurrent / totalTarget) * 1000) / 10;
+    const mebibyte = 1024 * 1024;
+
+    if (left > mebibyte) {
+      throw new Error(`Sorry, Oasis has only processed ${percent}% of the messages and needs to catch up.
+       Thanks for your patience, please wait for a moment and refresh this page to try again.`);
+    } else {
+      await next();
+    }
+  },
   routes
 ];
 


### PR DESCRIPTION
Problem: When our views are still indexing the database they apparently
don't respond over MuxRPC, which means that we're just waiting forever
until they finish. This means that people who are indexing the database
get an HTTP response that might take an hour to finish.

Solution: If we have more than 1 mebibyte of backlog, present an error
message explaining the situation and asking for a bit of patience.
