### PR TITLE
Fix link to popular view in navigation

### DIFF
--- a/src/views/index.js
+++ b/src/views/index.js
@@ -104,7 +104,11 @@ const template = (...elements) => {
             emoji: "🗺️",
             text: i18n.extended
           }),
-          navLink({ href: "/", emoji: "📣", text: i18n.popular }),
+          navLink({
+            href: "/public/popular/day",
+            emoji: "📣",
+            text: i18n.popular
+          }),
           navLink({ href: "/public/latest", emoji: "🐇", text: i18n.latest }),
           navLink({
             href: "/public/latest/topics",


### PR DESCRIPTION
## What's the problem you solved?

The link to the popular view in the navigation was broken after changing the root to /mentions.

## What solution are you recommending?

Added direkt link to popular view instead of root.
