### PR TITLE
Added reference to "plain text" instead of just text

### DIFF
--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -164,7 +164,7 @@ module.exports = {
     editProfile: "Edit profile",
     editProfileDescription:
       "Edit your profile with Markdown. Old versions of your profile information still exist and can't be deleted, but most SSB apps don't show them.",
-    profileName: "Profile name (text)",
+    profileName: "Profile name (plain text)",
     profileImage: "Profile image",
     profileDescription: "Profile description (Markdown)",
     hashtagDescription:


### PR DESCRIPTION
## What's the problem you solved?
Text is ambiguous. Perhaps the full term "plain text" is better when compared to "Markdown"

## What solution are you recommending?
Added reference to "plain text" instead of just text