### PR TITLE
Fix issue w/ mkdirp race condition

### DIFF
--- a/contrib/install-systemd-service.js
+++ b/contrib/install-systemd-service.js
@@ -21,7 +21,7 @@ const targetPath = path.join(systemdUserHome, "oasis.service");
 if (fs.existsSync(targetPath)) {
   console.log("Cowardly refusing to overwrite file:", targetPath);
 } else {
-  mkdirp(systemdUserHome);
+  mkdirp.sync(systemdUserHome);
 
   const sourcePath = path.join(__dirname, "oasis.service");
   fs.copyFileSync(sourcePath, targetPath);


### PR DESCRIPTION
Previously you would get this error due to imperfect path creation

```
node contrib/install-systemd-service.js
fs.js:114
    throw err;
    ^

Error: ENOENT: no such file or directory, copyfile '/home/justin/src/github.com/fraction/oasis/contrib/oasis.service' -> '/home/justin/.config/systemd/user/oasis.service'
    at Object.copyFileSync (fs.js:1728:3)
    at Object.<anonymous> (/home/justin/src/github.com/fraction/oasis/contrib/install-systemd-service.js:27:6)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
```