### PR TITLE
Indexing error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -774,9 +774,10 @@ const middleware = [
     const percent = Math.floor((totalCurrent / totalTarget) * 1000) / 10;
     const mebibyte = 1024 * 1024;
 
-    if (left > mebibyte) {
-      throw new Error(`Sorry, Oasis has only processed ${percent}% of the messages and needs to catch up.
-       Thanks for your patience, please wait for a moment and refresh this page to try again.`);
+    if (true || left > mebibyte) {
+      ctx.response.body = "<h1>Hey Christian, put the error message nicely here.</h1>"
+      // throw new Error(`Sorry, Oasis has only processed ${percent}% of the messages and needs to catch up.
+      //  Thanks for your patience, please wait for a moment and refresh this page to try again.`);
     } else {
       await next();
     }

--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,7 @@ const {
   authorView,
   commentView,
   editProfileView,
-  errorView,
+  indexingView,
   extendedView,
   latestView,
   likesView,
@@ -776,9 +776,7 @@ const middleware = [
     const mebibyte = 1024 * 1024;
 
     if (left > mebibyte) {
-      ctx.response.body = errorView({
-        message: `Oasis has only processed ${percent}% of the messages and needs to catch up. This page will refresh every 10 seconds. Thanks for your patience! ❤`
-      });
+      ctx.response.body = indexingView({ percent });
     } else {
       await next();
     }

--- a/src/index.js
+++ b/src/index.js
@@ -145,6 +145,7 @@ const {
   authorView,
   commentView,
   editProfileView,
+  errorView,
   extendedView,
   latestView,
   likesView,
@@ -774,10 +775,10 @@ const middleware = [
     const percent = Math.floor((totalCurrent / totalTarget) * 1000) / 10;
     const mebibyte = 1024 * 1024;
 
-    if (true || left > mebibyte) {
-      ctx.response.body = "<h1>Hey Christian, put the error message nicely here.</h1>"
-      // throw new Error(`Sorry, Oasis has only processed ${percent}% of the messages and needs to catch up.
-      //  Thanks for your patience, please wait for a moment and refresh this page to try again.`);
+    if (left > mebibyte) {
+      ctx.response.body = errorView({
+        message: `Oasis has only processed ${percent}% of the messages and needs to catch up. This page will refresh every 10 seconds. Thanks for your patience! ❤`
+      });
     } else {
       await next();
     }

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1028,3 +1028,38 @@ exports.hashtagView = ({ messages, hashtag }) => {
     messages.map(msg => post({ msg }))
   );
 };
+
+exports.indexingView = ({ percent }) => {
+  return template(
+    section(
+      p(
+        `Sorry, Oasis has only processed ${percent}% of the messages and needs to catch up. Thanks for your patience, please wait for a moment and refresh this page to try again.`
+      )
+    )
+  );
+};
+
+exports.errorView = ({ message }) => {
+  const nodes = html(
+    { lang: "en" },
+    head(
+      title("Oasis -- Error"),
+      link({ rel: "icon", type: "image/svg+xml", href: "/assets/favicon.svg" }),
+      meta({ charset: "utf-8" }),
+      meta({
+        name: "description",
+        content: i18n.oasisDescription
+      }),
+      meta({
+        name: "viewport",
+        content: toAttributes({ width: "device-width", "initial-scale": 1 })
+      }),
+      meta({ "http-equiv": "refresh", content: 10 })
+    ),
+    body(main({ id: "content" }, p(message)))
+  );
+
+  const result = doctypeString + nodes.outerHTML;
+
+  return result;
+};

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1030,20 +1030,13 @@ exports.hashtagView = ({ messages, hashtag }) => {
 };
 
 exports.indexingView = ({ percent }) => {
-  return template(
-    section(
-      p(
-        `Sorry, Oasis has only processed ${percent}% of the messages and needs to catch up. Thanks for your patience, please wait for a moment and refresh this page to try again.`
-      )
-    )
-  );
-};
+  // TODO: i18n
+  const message = `Oasis has only processed ${percent}% of the messages and needs to catch up. This page will refresh every 10 seconds. Thanks for your patience! ❤`;
 
-exports.errorView = ({ message }) => {
   const nodes = html(
     { lang: "en" },
     head(
-      title("Oasis -- Error"),
+      title("Oasis"),
       link({ rel: "icon", type: "image/svg+xml", href: "/assets/favicon.svg" }),
       meta({ charset: "utf-8" }),
       meta({
@@ -1056,7 +1049,13 @@ exports.errorView = ({ message }) => {
       }),
       meta({ "http-equiv": "refresh", content: 10 })
     ),
-    body(main({ id: "content" }, p(message)))
+    body(
+      main(
+        { id: "content" },
+        p(message),
+        progress({ value: percent, max: 100 })
+      )
+    )
   );
 
   const result = doctypeString + nodes.outerHTML;


### PR DESCRIPTION
Problem: The indexing message is being thrown as an error, which is
pasted as plaintext, so we can't do a page refresh. This is frustrating
when you're waiting for the indexes to finish because you have to
manually refresh a bunch while you wait.

Solution: Use the prototype from @justinabrahms to add an HTML message
for the indexing error and automatically refresh the page every ten
seconds.