### PR TITLE
Fix crash when linking directly to private message

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -1052,17 +1052,22 @@ module.exports = ({ cooler, isPublic }) => {
                 debug("getting root ancestor of %s", msg.key);
 
                 if (typeof msg.value.content === "string") {
-                  debug("private message");
                   // Private message we can't decrypt, stop looking for parents.
-                  resolve(parents);
-                }
-
-                if (msg.value.content.type !== "post") {
+                  debug("private message");
+                  if (parents.length > 0) {
+                    // If we already have some parents, return those.
+                    resolve(parents);
+                  } else {
+                    // If we don't know of any parents, resolve this message.
+                    resolve(msg);
+                  }
+                } else if (msg.value.content.type !== "post") {
                   debug("not a post");
                   resolve(msg);
-                }
-
-                if (isLooseReply(msg) && ssbRef.isMsg(msg.value.content.fork)) {
+                } else if (
+                  isLooseReply(msg) &&
+                  ssbRef.isMsg(msg.value.content.fork)
+                ) {
                   debug("reply, get the parent");
                   try {
                     // It's a message reply, get the parent!


### PR DESCRIPTION
Problem: Trying to view a private message crashes the server and leaks a
bunch of memory. That's bad. This problem is caused by faulty handling
in the function that finds thread ancestors. There's some code that says
"if the next ancestor is a private message, just return the ancestors
that we know about", which returns nothing when we're looking up a
private post (because we can't identify *any* ancestors).

Solution: Ensure that we're only resolving the promise once in the
function by chaining `else if`s and ensure that we only return the
ancestor list if there are actually ancestor in it. If the ancestor list
is empty, we can just return the single message that we know about and
pass it off.