### PR TITLE
Actually shift cards over, rather than just a minor indent.

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -517,6 +517,6 @@ hr {
  * be wise to nest these recursively on the thread view, which would make it so
  * that we don't need any inline CSS anymore.
  */
-.indent {
-  margin-left: 1rem;
+.indent > section {
+  margin-left: 2rem;
 }


### PR DESCRIPTION
## What's the problem you solved?
Previously, there was a minor indent on threads, which made it visually difficult to determine which things were replies and which were new posts. 

## What solution are you recommending?
This addresses that concern by shifting the individual cards over, which makes them visually distinct. 

Additionally, it doesn't move the sidebar over at all, so there's no weirdness as you navigate tabs.

Fixes #336 