### PR TITLE
Don't append channel to non-root posts

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -466,10 +466,17 @@ module.exports = ({ cooler, isPublic }) => {
           }
         }
 
+        const isPost =
+          lodash.get(msg, "value.content.type") === "post" &&
+          lodash.get(msg, "value.content.text", false) !== false;
+        const hasRoot = lodash.get(msg, "value.content.root", false) !== false;
+        const hasFork = lodash.get(msg, "value.content.fork", false) !== false;
+
         const channel = lodash.get(msg, "value.content.channel");
         const hasChannel = typeof channel === "string" && channel.length > 2;
+        const isRoot = hasRoot === false;
 
-        if (hasChannel) {
+        if (hasChannel && isRoot) {
           msg.value.content.text += `\n\n#${channel}`;
         }
 
@@ -502,12 +509,6 @@ module.exports = ({ cooler, isPublic }) => {
           id: avatarId,
           url: avatarUrl
         });
-
-        const isPost =
-          lodash.get(msg, "value.content.type") === "post" &&
-          lodash.get(msg, "value.content.text") != null;
-        const hasRoot = lodash.get(msg, "value.content.root") != null;
-        const hasFork = lodash.get(msg, "value.content.fork") != null;
 
         if (isPost && hasRoot === false && hasFork === false) {
           lodash.set(msg, "value.meta.postType", "post");


### PR DESCRIPTION
Problem: When publishing a root post, other clients give you the option
of adding a `channel` property, which is basically just a hashtag. We
show this at the end of the message, but since replies often copy the
`channel` property then it gets appended to every reply.

Solution: Only append the channel as a hashtag for root posts.