### PR TITLE
Only show connected peers in settings

### DIFF
--- a/src/views/index.js
+++ b/src/views/index.js
@@ -766,14 +766,16 @@ exports.settingsView = ({ status, peers, theme, themeNames, version }) => {
     stopButton
   ]);
 
-  const peerList = (peers || []).map(([, data]) => {
-    return li(
-      a(
-        { href: `/author/${encodeURIComponent(data.key)}` },
-        data.name || data.host || data.key
-      )
-    );
-  });
+  const peerList = (peers || [])
+    .filter(([, data]) => data.state === "connected")
+    .map(([, data]) => {
+      return li(
+        a(
+          { href: `/author/${encodeURIComponent(data.key)}` },
+          data.name || data.host || data.key
+        )
+      );
+    });
 
   const themeElements = themeNames.map(cur => {
     const isCurrentTheme = cur === theme;


### PR DESCRIPTION
Problem: The peer list shows peers that are connected and in the process
of establishing a new connection, which has lots of turbulence. It's
confusing to see dozens of "connections" that only exist for a few
milliseconds when they're actually just connection attempts.

Solution: Only show peers with the state "connected".