### PR TITLE
Load theme using existing config mechanisms

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -43,4 +43,9 @@ module.exports = (presets, defaultConfigFile) =>
       default: _.get(presets, "debug", false),
       type: "boolean"
     })
+    .options("theme", {
+      describe: "The theme to use, if a theme hasn't been set in the cookies",
+      default: _.get(presets, "theme", "atelier-sulphurPool-light"),
+      type: "string"
+    })
     .epilog(`The defaults can be configured in ${defaultConfigFile}.`).argv;

--- a/src/index.js
+++ b/src/index.js
@@ -173,8 +173,6 @@ try {
   // Optional dependency
 }
 
-const defaultTheme = "atelier-sulphurPool-light".toLowerCase();
-
 const readmePath = path.join(__dirname, "..", "README.md");
 const packagePath = path.join(__dirname, "..", "package.json");
 
@@ -320,7 +318,7 @@ router
     ctx.body = await hashtagView({ hashtag, messages });
   })
   .get("/theme.css", ctx => {
-    const theme = ctx.cookies.get("theme") || defaultTheme;
+    const theme = ctx.cookies.get("theme") || config.theme;
 
     const packageName = "@fraction/base16-css";
     const filePath = `${packageName}/src/base16-${theme}.css`;
@@ -500,7 +498,7 @@ router
     ctx.body = await image({ blobId, imageSize: Number(imageSize) });
   })
   .get("/settings/", async ctx => {
-    const theme = ctx.cookies.get("theme") || defaultTheme;
+    const theme = ctx.cookies.get("theme") || config.theme;
     const getMeta = async ({ theme }) => {
       const status = await meta.status();
       const peers = await meta.peers();

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -125,7 +125,7 @@ module.exports = {
     ],
     theme: "Theme",
     themeIntro:
-      "Choose from any theme you'd like. The default theme is Atelier-SulphurPool-Light.",
+      "Choose from any theme you'd like. The default theme is Atelier-SulphurPool-Light. You can also set your theme in the default configuration file.",
     setTheme: "Set theme",
     language: "Language",
     languageDescription:


### PR DESCRIPTION
## What's the problem you solved?

Closes #333 

## What solution are you recommending?

By using the existing config mechanism, this allow someone to pass in the theme as a command line arg or set the theme in `defaults.json`, while still allowing someone to set the theme on a per-browser basis as a cookie.