### PR TITLE
Remove version question from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,3 @@
 ## What's the problem you want solved?
 
 ## Is there a solution you'd like to recommend?
-
-## What version or commit of Oasis are you using?


### PR DESCRIPTION
Problem: Almost everyone is on the latest version and we probably don't
need to ask for what version they're using.

Solution: Remove the question.