### PR TITLE
Fix theme using capitalization

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -47,6 +47,7 @@
     "socio",
     "ssbc",
     "summerfruit",
+    "sulphurpool",
     "systemctl",
     "systemd",
     "unfollow",

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,7 +45,7 @@ module.exports = (presets, defaultConfigFile) =>
     })
     .options("theme", {
       describe: "The theme to use, if a theme hasn't been set in the cookies",
-      default: _.get(presets, "theme", "atelier-sulphurPool-light"),
+      default: _.get(presets, "theme", "atelier-sulphurpool-light"),
       type: "string",
     })
     .epilog(`The defaults can be configured in ${defaultConfigFile}.`).argv;


### PR DESCRIPTION
Problem: Capitalization in "sulphurPool" was causing a file not found.

Solution: Repalce "sulphurPool" with "sulphurpool".