### PR TITLE
Add .mailmap for canonical identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Cinnamon <cinnamon_oasis@fastmail.com> <cinnamon_bun_github@fastmail.com>
+Cinnamon <cinnamon_oasis@fastmail.com> <32660718+cinnamon-bun@users.noreply.github.com>
+Jonathan Dahan <github@jonathan.is> <hi@jonathan.is>
+kawaiipunk <kawaiipunk@posteo.net> <georgeowell@users.noreply.github.com>


### PR DESCRIPTION
Problem: Some of us have a few different emails, which show up as
different people when we commit. It would be great to merge these Git
identities so that they don't show up as different people.

Solution: Use `.mailmap`, which lets people choose their favorite
canonical email address for this project.