### PR TITLE
Use blockquote on replies for text-based browser indent

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -534,8 +534,10 @@ hr {
  * that we don't need any inline CSS anymore.
  */
 .indent {
-  padding-left: 1rem;
+  padding-left: var(--whole);
   border-left: var(--micro) solid var(--bg-selection);
+  margin-right: 0;
+  margin-left: var(--whole);
 }
 
 .theme-preview {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -8,6 +8,7 @@ const MarkdownIt = require("markdown-it");
 const {
   a,
   article,
+  blockquote,
   br,
   body,
   button,
@@ -422,7 +423,7 @@ const postAside = ({ key, value }) => {
     fragments.push(section(continueThreadComponent(thread, isComment)));
   }
 
-  return div({ class: "indent" }, fragments);
+  return blockquote({ class: "indent" }, fragments);
 };
 
 const post = ({ msg, aside = false }) => {


### PR DESCRIPTION
## What's the problem you solved?

In a text-based browser, replies in threads were displayed at the same level, making it hard to distinguish what was the root. Relates to #329 and #336.

## What solution are you recommending?

Text-based browsers recognize `<blockquote>`
and indent as expected. This helps render threads with indents in a
similar way as Oasis now does in the graphical browser.

This renders as:

```
[]Kathleen Marie 2h

Enjoying all the neighborhood flowers that are in bloom.

IMG_0186.jpg
IMG_0190.jpg

❤ 5
Comment JSON


    []Christian Bundy commented on thread 1h

    @Kathleen Marie

    Walks make lockdown so much more fun.

    ❤ 3
    Comment Reply JSON
```