### PR TITLE
Avoid processing popular posts twice

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -1065,7 +1065,7 @@ module.exports = ({ cooler, isPublic }) => {
                   if (err) {
                     reject(err);
                   } else {
-                    resolve(transform(ssb, collectedMessages, myFeedId));
+                    resolve(collectedMessages);
                   }
                 })
               );


### PR DESCRIPTION
Problem: Messages are being fetched with `post.get()`, which runs the
`transform()` function to decorate them with Markdown/etc, but then
they're being passed through `transform()` a second time at the end of
the function. This is inefficient and applies side-effects (like adding
channels to the post) twice.

Solution: Remove the final `transform()` so that these posts are only
decorated once.

Fixes: https://github.com/fraction/oasis/issues/358

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `curl http://old/public/popular/day` | 908.5 ± 59.2 | 851.9 | 998.5 | 1.42 ± 0.16 |
| `curl http://new/public/popular/day` | 641.2 ± 57.2 | 579.6 | 751.6 | 1.00 |
