### PR TITLE
Add contributing and maintainting documents

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,0 +1,130 @@
+# Collective Code Construction Contract - Oasis Implementation
+
+The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](https://help.github.com/articles/about-pull-requests/), aimed at providing an optimal collaboration model for free software projects.
+This is the Oasis-specific implementation, based on [revision 2 of C4](https://github.com/zeromq/rfc/blob/63024673f19ad136652ff7b3bfb3a6547811e006/42/README.md).
+
+## Summary
+
+Thank you for contributing to Oasis! Here we try capture how we collaborate, and why we do it this way.
+
+This entire document is open for changes, if there is anything that is confusing or can be improved, please start a discussion with us!
+
+## License
+
+Copyright (c) 2009-2016 Pieter Hintjens.
+
+This Specification is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
+
+This Specification is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, see <http://www.gnu.org/licenses>.
+
+## Abstract
+
+C4 provides a standard process for contributing, evaluating and discussing improvements on software projects. It defines specific technical requirements for projects like a style guide, unit tests, `git` and similar platforms. It also establishes different personas for projects, with clear and distinct duties. C4 specifies a process for documenting and discussing issues including seeking consensus and clear descriptions, use of "pull requests" and systematic reviews.
+
+## Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+
+## 1. Goals
+
+C4 is meant to provide a reusable optimal collaboration model for open source software projects. It has these specific goals:
+
+1. To maximize the scale and diversity of the community around a project, by reducing the friction for new Contributors and creating a scaled participation model with strong positive feedbacks;
+1. To relieve dependencies on key individuals by separating different skill sets so that there is a larger pool of competence in any required domain;
+1. To allow the project to develop faster and more accurately, by increasing the diversity of the decision making process;
+1. To support the natural life cycle of project versions from experimental through to stable, by allowing safe experimentation, rapid failure, and isolation of stable code;
+1. To reduce the internal complexity of project repositories, thus making it easier for Contributors to participate and reducing the scope for error;
+1. To enforce collective ownership of the project, which increases economic incentive to Contributors and reduces the risk of hijack by hostile entities.
+
+## 2. Design
+
+### 2.1. Preliminaries
+
+1. The project MUST use the git distributed revision control system.
+1. The project MUST be hosted on github.com or equivalent, herein called the "Platform".
+1. The project MUST use the Platform issue tracker.
+1. The project SHOULD have clearly documented guidelines for code style.
+1. A "Contributor" is a person who wishes to provide a patch, being a set of commits that solve some clearly identified problem.
+1. A "Maintainer" is a person who merges patches to the project. Maintainers are not developers; their job is to enforce process.
+1. Contributors MUST NOT have commit access to the repository unless they are also Maintainers.
+1. Maintainers MUST have commit access to the repository.
+1. Everyone, without distinction or discrimination, MUST have an equal right to become a Contributor under the terms of this contract.
+
+### 2.2. Licensing and Ownership
+
+1. The project MUST use a share-alike license such as the MPLv2, or a GPLv3 variant thereof (GPL, LGPL, AGPL).
+1. All contributions to the project source code ("patches") MUST use the same license as the project.
+1. All patches are owned by their authors. There MUST NOT be any copyright assignment process.
+1. Each Contributor MUST be responsible for identifying themselves in the project Contributor list.
+
+### 2.3. Patch Requirements
+
+1. Maintainers and Contributors MUST have a Platform account and SHOULD use their real names or a well-known alias.
+1. A patch SHOULD be a minimal and accurate answer to exactly one identified and agreed problem.
+1. A patch MUST adhere to the code style guidelines of the project if these are defined.
+1. A patch MUST adhere to the "Evolution of Public Contracts" guidelines defined below.
+1. A patch MUST NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
+1. A patch MUST compile cleanly and pass project self-tests on at least the principal target platform.
+1. A patch commit message SHOULD consist of a single short (less than 50 characters) line stating the problem ("Problem: ...") being solved, followed by a blank line and then the proposed solution ("Solution: ...").
+1. A "Correct Patch" is one that satisfies the above requirements.
+
+### 2.4. Development Process
+
+1. Change on the project MUST be governed by the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.
+1. To request changes, a user SHOULD log an issue on the project Platform issue tracker.
+1. The user or Contributor SHOULD write the issue by describing the problem they face or observe.
+1. The user or Contributor SHOULD seek consensus on the accuracy of their observation, and the value of solving the problem.
+1. Users MUST NOT log feature requests, ideas, suggestions, or any solutions to problems that are not explicitly documented and provable.
+1. Thus, the release history of the project MUST be a list of meaningful issues logged and solved.
+1. To work on an issue, a Contributor MUST fork the project repository and then work on their forked repository.
+1. To submit a patch, a Contributor MUST create a Platform pull request back to the project.
+1. A Contributor MUST NOT commit changes directly to the project.
+1. If the Platform implements pull requests as issues, a Contributor MAY directly send a pull request without logging a separate issue.
+1. To discuss a patch, people MAY comment on the Platform pull request, on the commit, or elsewhere.
+1. To accept or reject a patch, a Maintainer MUST use the Platform interface.
+1. Maintainers SHOULD NOT merge their own patches except in exceptional cases, such as non-responsiveness from other Maintainers for an extended period (more than 1-2 days).
+1. Maintainers MUST NOT make value judgments on correct patches.
+1. Maintainers MUST merge correct patches from other Contributors rapidly.
+1. Maintainers MAY merge incorrect patches from other Contributors with the goals of (a) ending fruitless discussions, (b) capturing toxic patches in the historical record, (c) engaging with the Contributor on improving their patch quality.
+1. The user who created an issue SHOULD close the issue after checking the patch is successful.
+1. Any Contributor who has value judgments on a patch SHOULD express these via their own patches.
+1. Maintainers SHOULD close user issues that are left open without action for an uncomfortable period of time.
+
+### 2.5. Branches and Releases
+
+1. The project MUST have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
+1. The project MUST NOT use topic branches for any reason. Personal forks MAY use topic branches.
+1. To make a stable release a Maintainer must tag the repository. Stable releases MUST always be released from the repository master.
+
+### 2.6. Evolution of Public Contracts
+
+1. All Public Contracts (APIs or protocols) MUST be documented.
+1. All Public Contracts SHOULD have space for extensibility and experimentation.
+1. A patch that modifies a stable Public Contract SHOULD not break existing applications unless there is overriding consensus on the value of doing this.
+1. A patch that introduces new features SHOULD do so using new names (a new contract).
+1. New contracts SHOULD be marked as "draft" until they are stable and used by real users.
+1. Old contracts SHOULD be deprecated in a systematic fashion by marking them as "deprecated" and replacing them with new contracts as needed.
+1. When sufficient time has passed, old deprecated contracts SHOULD be removed.
+1. Old names MUST NOT be reused by new contracts.
+
+### 2.7. Project Administration
+
+1. The project founders MUST act as Administrators to manage the set of project Maintainers.
+1. The Administrators MUST ensure their own succession over time by promoting the most effective Maintainers.
+1. A new Contributor who makes correct patches, who clearly understands the project goals, and the process SHOULD be invited to become a Maintainer.
+1. Administrators SHOULD remove Maintainers who are inactive for an extended period of time, or who repeatedly fail to apply this process accurately.
+1. Administrators SHOULD block or ban "bad actors" who cause stress and pain to others in the project. This should be done after public discussion, with a chance for all parties to speak. A bad actor is someone who repeatedly ignores the rules and culture of the project, who is needlessly argumentative or hostile, or who is offensive, and who is unable to self-correct their behavior when asked to do so by others.
+
+## Further Reading
+
+- [Argyris' Models 1 and 2](http://en.wikipedia.org/wiki/Chris_Argyris) - the goals of C4 are consistent with Argyris' Model 2.
+
+- [Toyota Kata](http://en.wikipedia.org/wiki/Toyota_Kata) - covering the Improvement Kata (fixing problems one at a time) and the Coaching Kata (helping others to learn the Improvement Kata).
+
+## Implementations
+
+- The [ZeroMQ community](http://zeromq.org) uses the C4 process for many projects.
+- [OSSEC](http://www.ossec.net/) [uses the C4 process](https://ossec-docs.readthedocs.org/en/latest/development/oRFC/orfc-1.html).
+- The [Machinekit](http://www.machinekit.io/) community [uses the C4 process](http://www.machinekit.io/about/).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,11 +28,15 @@ is giving you any trouble.
 
 ### Unknown word
 
+<!-- spell-checker:disable -->
+
 ```
 /src/index.js:10:42 - Unknown word (Scuttlebtut)
 ```
 
-If this word is a typo, please fix the typo. If this error is a mistake, and
+<!-- spell-checker:enable -->
+
+If this word is a tpo, please fix the typo. If this error is a mistake, and
 you're sure that this is a word, please add the word to `.cspell.json`.
 
 ### Code style issues found

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,130 +1,61 @@
-# Collective Code Construction Contract - Oasis Implementation
+# Contributing
 
-The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](https://help.github.com/articles/about-pull-requests/), aimed at providing an optimal collaboration model for free software projects.
-This is the Oasis-specific implementation, based on [revision 2 of C4](https://github.com/zeromq/rfc/blob/63024673f19ad136652ff7b3bfb3a6547811e006/42/README.md).
+If you want to dive into the details, please see the [contract](./contract)
+that defines the contributor role in this project. If you're comfortable with
+a top-level summary, you can start here first.
 
-## Summary
+Our workflow is basically [GitHub Flow][github-flow] with specific roles:
 
-Thank you for contributing to Oasis! Here we try capture how we collaborate, and why we do it this way.
+- **Contributor:** Write patches that reduce the number of problems.
+- **Maintainers:** Merge patches that reduce the number of problems.
 
-This entire document is open for changes, if there is anything that is confusing or can be improved, please start a discussion with us!
+If you have an issue, it's best to open an issue to describe the problem and
+discuss solutions, but don't worry if you've already skipped that step.
 
-## License
+Assuming you already have a [developer install](./install.md) you should be
+able to start editing source code. There are a few useful commands you should
+know about:
 
-Copyright (c) 2009-2016 Pieter Hintjens.
+- **`npm install`**: Ensure that software dependencies are installed.
+- **`npm test`**: Ensure that all automated tests pass.
+- **`npm run fix`**: If an automated test failed, this may fix it.
 
-This Specification is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
+Please run `npm test` before writing a commit, because if there are errors then
+maintainers won't be able to merge your patch. Please ask for help if `npm test`
+is giving you any trouble.
 
-This Specification is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+## Frequently Failed Tests
 
-You should have received a copy of the GNU General Public License along with this program; if not, see <http://www.gnu.org/licenses>.
+### Unknown word
 
-## Abstract
+```
+/src/index.js:10:42 - Unknown word (Scuttlebtut)
+```
 
-C4 provides a standard process for contributing, evaluating and discussing improvements on software projects. It defines specific technical requirements for projects like a style guide, unit tests, `git` and similar platforms. It also establishes different personas for projects, with clear and distinct duties. C4 specifies a process for documenting and discussing issues including seeking consensus and clear descriptions, use of "pull requests" and systematic reviews.
+If this word is a typo, please fix the typo. If this error is a mistake, and
+you're sure that this is a word, please add the word to `.cspell.json`.
 
-## Language
+### Code style issues found
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+```
+Checking formatting...
+src/index.js
+README.md
+Code style issues found in the above file(s). Forgot to run Prettier?
+```
 
-## 1. Goals
+You can use `npm run fix` to resolve inconsistent code style. Please remember to
+add those changes with `git add` or similar before you commit.
 
-C4 is meant to provide a reusable optimal collaboration model for open source software projects. It has these specific goals:
+## Tips
 
-1. To maximize the scale and diversity of the community around a project, by reducing the friction for new Contributors and creating a scaled participation model with strong positive feedbacks;
-1. To relieve dependencies on key individuals by separating different skill sets so that there is a larger pool of competence in any required domain;
-1. To allow the project to develop faster and more accurately, by increasing the diversity of the decision making process;
-1. To support the natural life cycle of project versions from experimental through to stable, by allowing safe experimentation, rapid failure, and isolation of stable code;
-1. To reduce the internal complexity of project repositories, thus making it easier for Contributors to participate and reducing the scope for error;
-1. To enforce collective ownership of the project, which increases economic incentive to Contributors and reduces the risk of hijack by hostile entities.
+### TypeScript opportunities
 
-## 2. Design
+If you're looking for places where TypeScript would enjoy more detail, you can
+run the TypeScript linter with `--noImplicitAny`:
 
-### 2.1. Preliminaries
+```sh
+npx tsc --allowJs --resolveJsonModule --lib es2018,dom --checkJs --noEmit --skipLibCheck --noImplicitAny src/index.js
+```
 
-1. The project MUST use the git distributed revision control system.
-1. The project MUST be hosted on github.com or equivalent, herein called the "Platform".
-1. The project MUST use the Platform issue tracker.
-1. The project SHOULD have clearly documented guidelines for code style.
-1. A "Contributor" is a person who wishes to provide a patch, being a set of commits that solve some clearly identified problem.
-1. A "Maintainer" is a person who merges patches to the project. Maintainers are not developers; their job is to enforce process.
-1. Contributors MUST NOT have commit access to the repository unless they are also Maintainers.
-1. Maintainers MUST have commit access to the repository.
-1. Everyone, without distinction or discrimination, MUST have an equal right to become a Contributor under the terms of this contract.
-
-### 2.2. Licensing and Ownership
-
-1. The project MUST use a share-alike license such as the MPLv2, or a GPLv3 variant thereof (GPL, LGPL, AGPL).
-1. All contributions to the project source code ("patches") MUST use the same license as the project.
-1. All patches are owned by their authors. There MUST NOT be any copyright assignment process.
-1. Each Contributor MUST be responsible for identifying themselves in the project Contributor list.
-
-### 2.3. Patch Requirements
-
-1. Maintainers and Contributors MUST have a Platform account and SHOULD use their real names or a well-known alias.
-1. A patch SHOULD be a minimal and accurate answer to exactly one identified and agreed problem.
-1. A patch MUST adhere to the code style guidelines of the project if these are defined.
-1. A patch MUST adhere to the "Evolution of Public Contracts" guidelines defined below.
-1. A patch MUST NOT include non-trivial code from other projects unless the Contributor is the original author of that code.
-1. A patch MUST compile cleanly and pass project self-tests on at least the principal target platform.
-1. A patch commit message SHOULD consist of a single short (less than 50 characters) line stating the problem ("Problem: ...") being solved, followed by a blank line and then the proposed solution ("Solution: ...").
-1. A "Correct Patch" is one that satisfies the above requirements.
-
-### 2.4. Development Process
-
-1. Change on the project MUST be governed by the pattern of accurately identifying problems and applying minimal, accurate solutions to these problems.
-1. To request changes, a user SHOULD log an issue on the project Platform issue tracker.
-1. The user or Contributor SHOULD write the issue by describing the problem they face or observe.
-1. The user or Contributor SHOULD seek consensus on the accuracy of their observation, and the value of solving the problem.
-1. Users MUST NOT log feature requests, ideas, suggestions, or any solutions to problems that are not explicitly documented and provable.
-1. Thus, the release history of the project MUST be a list of meaningful issues logged and solved.
-1. To work on an issue, a Contributor MUST fork the project repository and then work on their forked repository.
-1. To submit a patch, a Contributor MUST create a Platform pull request back to the project.
-1. A Contributor MUST NOT commit changes directly to the project.
-1. If the Platform implements pull requests as issues, a Contributor MAY directly send a pull request without logging a separate issue.
-1. To discuss a patch, people MAY comment on the Platform pull request, on the commit, or elsewhere.
-1. To accept or reject a patch, a Maintainer MUST use the Platform interface.
-1. Maintainers SHOULD NOT merge their own patches except in exceptional cases, such as non-responsiveness from other Maintainers for an extended period (more than 1-2 days).
-1. Maintainers MUST NOT make value judgments on correct patches.
-1. Maintainers MUST merge correct patches from other Contributors rapidly.
-1. Maintainers MAY merge incorrect patches from other Contributors with the goals of (a) ending fruitless discussions, (b) capturing toxic patches in the historical record, (c) engaging with the Contributor on improving their patch quality.
-1. The user who created an issue SHOULD close the issue after checking the patch is successful.
-1. Any Contributor who has value judgments on a patch SHOULD express these via their own patches.
-1. Maintainers SHOULD close user issues that are left open without action for an uncomfortable period of time.
-
-### 2.5. Branches and Releases
-
-1. The project MUST have one branch ("master") that always holds the latest in-progress version and SHOULD always build.
-1. The project MUST NOT use topic branches for any reason. Personal forks MAY use topic branches.
-1. To make a stable release a Maintainer must tag the repository. Stable releases MUST always be released from the repository master.
-
-### 2.6. Evolution of Public Contracts
-
-1. All Public Contracts (APIs or protocols) MUST be documented.
-1. All Public Contracts SHOULD have space for extensibility and experimentation.
-1. A patch that modifies a stable Public Contract SHOULD not break existing applications unless there is overriding consensus on the value of doing this.
-1. A patch that introduces new features SHOULD do so using new names (a new contract).
-1. New contracts SHOULD be marked as "draft" until they are stable and used by real users.
-1. Old contracts SHOULD be deprecated in a systematic fashion by marking them as "deprecated" and replacing them with new contracts as needed.
-1. When sufficient time has passed, old deprecated contracts SHOULD be removed.
-1. Old names MUST NOT be reused by new contracts.
-
-### 2.7. Project Administration
-
-1. The project founders MUST act as Administrators to manage the set of project Maintainers.
-1. The Administrators MUST ensure their own succession over time by promoting the most effective Maintainers.
-1. A new Contributor who makes correct patches, who clearly understands the project goals, and the process SHOULD be invited to become a Maintainer.
-1. Administrators SHOULD remove Maintainers who are inactive for an extended period of time, or who repeatedly fail to apply this process accurately.
-1. Administrators SHOULD block or ban "bad actors" who cause stress and pain to others in the project. This should be done after public discussion, with a chance for all parties to speak. A bad actor is someone who repeatedly ignores the rules and culture of the project, who is needlessly argumentative or hostile, or who is offensive, and who is unable to self-correct their behavior when asked to do so by others.
-
-## Further Reading
-
-- [Argyris' Models 1 and 2](http://en.wikipedia.org/wiki/Chris_Argyris) - the goals of C4 are consistent with Argyris' Model 2.
-
-- [Toyota Kata](http://en.wikipedia.org/wiki/Toyota_Kata) - covering the Improvement Kata (fixing problems one at a time) and the Coaching Kata (helping others to learn the Improvement Kata).
-
-## Implementations
-
-- The [ZeroMQ community](http://zeromq.org) uses the C4 process for many projects.
-- [OSSEC](http://www.ossec.net/) [uses the C4 process](https://ossec-docs.readthedocs.org/en/latest/development/oRFC/orfc-1.html).
-- The [Machinekit](http://www.machinekit.io/) community [uses the C4 process](http://www.machinekit.io/about/).
+[github-flow]: https://guides.github.com/introduction/flow/

--- a/docs/maintaining.md
+++ b/docs/maintaining.md
@@ -1,0 +1,28 @@
+# Maintaining
+
+Please read the [contract](./contract) that defines the maintainer role in this
+project. In short:
+
+- Please merge any patches that reduce the number of problems in this project.
+- If you have small nitpicks about a patch, please merge the patch and write a
+  new patch with your preferred improvements.
+- **Take care of yourself and don't burn out.** Please don't sacrifice your
+  health to improve this project, and know that there are much more important
+  things in life than merging pull requests quickly.
+
+## Tips
+
+### Checking out a patch
+
+If you want to check out pull request number 42 and you're comfortable running
+the code on your local device.
+
+```sh
+remote="https://github.com/fraction/oasis.git"
+git fetch "$remote"
+git reset --hard $remote master
+git pull "$remote" pull/42/head
+npm ci && npm test && npm start
+```
+
+No need to add their fork as a remote.


### PR DESCRIPTION
Problem: We had our contract in `contributing.md` but that didn't really
give actionable information on how to contribute or how to maintain this
project.

Solution: Move contract to `contract.md` and start documents for
contributing and maintaining.