### PR TITLE
Add block and unblock to author profile

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -353,7 +353,7 @@ router
       name,
       description,
       avatarUrl,
-      relationship: null,
+      relationship: { me: true },
     });
   })
   .get("/profile/edit", async (ctx) => {

--- a/src/index.js
+++ b/src/index.js
@@ -681,6 +681,18 @@ router
     ctx.body = await friend.unfollow(feed);
     ctx.redirect(referer.href);
   })
+  .post("/block/:feed", koaBody(), async (ctx) => {
+    const { feed } = ctx.params;
+    const referer = new URL(ctx.request.header.referer);
+    ctx.body = await friend.block(feed);
+    ctx.redirect(referer.href);
+  })
+  .post("/unblock/:feed", koaBody(), async (ctx) => {
+    const { feed } = ctx.params;
+    const referer = new URL(ctx.request.header.referer);
+    ctx.body = await friend.unblock(feed);
+    ctx.redirect(referer.href);
+  })
   .post("/like/:message", koaBody(), async (ctx) => {
     const { message } = ctx.params;
     // TODO: convert all so `message` is full message and `messageKey` is key

--- a/src/models.js
+++ b/src/models.js
@@ -203,12 +203,16 @@ module.exports = ({ cooler, isPublic }) => {
         blocking: false,
         following: false,
       }),
+    /**
+     * @param feedId {string}
+     * @returns {Promise<{me: boolean, following: boolean, blocking: boolean }>}
+     */
     getRelationship: async (feedId) => {
       const ssb = await cooler.open();
       const { id } = ssb;
 
       if (feedId === id) {
-        return null;
+        return { me: true, following: false, blocking: false };
       }
 
       const isFollowing = await ssb.friends.isFollowing({
@@ -222,6 +226,7 @@ module.exports = ({ cooler, isPublic }) => {
       });
 
       return {
+        me: false,
         following: isFollowing,
         blocking: isBlocking,
       };

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -59,6 +59,8 @@ const i18n = {
     // relationships
     unfollow: "Unfollow",
     follow: "Follow",
+    block: "Block",
+    unblock: "Unblock",
     relationshipFollowing: "You are following",
     relationshipYou: "This is you",
     relationshipBlocking: "You are blocking",

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -618,6 +618,9 @@ exports.editProfileView = ({ name, description }) =>
     )
   );
 
+/**
+ * @param {{avatarUrl: string, description: string, feedId: string, messages: any[], name: string, relationship: object}} input
+ */
 exports.authorView = ({
   avatarUrl,
   description,
@@ -647,7 +650,7 @@ exports.authorView = ({
       )
     );
 
-  if (relationship !== null) {
+  if (relationship.me === false) {
     if (relationship.following) {
       addForm({ action: "unfollow" });
     } else if (relationship.blocking) {
@@ -659,7 +662,7 @@ exports.authorView = ({
   }
 
   const relationshipText = (() => {
-    if (relationship === null) {
+    if (relationship.me === true) {
       return i18n.relationshipYou;
     } else if (
       relationship.following === true &&
@@ -703,7 +706,7 @@ exports.authorView = ({
         a({ href: `/likes/${encodeURIComponent(feedId)}` }, i18n.viewLikes),
         span(nbsp, relationshipText),
         ...contactForms,
-        relationship === null
+        relationship.me
           ? a({ href: `/profile/edit` }, nbsp, i18n.editProfile)
           : null
       ),

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -629,29 +629,34 @@ exports.authorView = ({
   const mention = `[@${name}](${feedId})`;
   const markdownMention = highlightJs.highlight("markdown", mention).value;
 
-  const areFollowing =
-    relationship !== null &&
-    relationship.following === true &&
-    relationship.blocking === false;
+  const contactForms = [];
 
-  const contactFormType = areFollowing ? "unfollow" : "follow";
-  const contactFormTypeLabel = i18n[contactFormType];
-
-  const contactForm =
-    relationship === null
-      ? null // We're on our own profile!
-      : form(
+  const addForm = ({ action }) =>
+    contactForms.push(
+      form(
+        {
+          action: `/${action}/${encodeURIComponent(feedId)}`,
+          method: "post",
+        },
+        button(
           {
-            action: `/${contactFormType}/${encodeURIComponent(feedId)}`,
-            method: "post",
+            type: "submit",
           },
-          button(
-            {
-              type: "submit",
-            },
-            contactFormTypeLabel
-          )
-        );
+          i18n[action]
+        )
+      )
+    );
+
+  if (relationship !== null) {
+    if (relationship.following) {
+      addForm({ action: "unfollow" });
+    } else if (relationship.blocking) {
+      addForm({ action: "unblock" });
+    } else {
+      addForm({ action: "follow" });
+      addForm({ action: "block" });
+    }
+  }
 
   const relationshipText = (() => {
     if (relationship === null) {
@@ -697,7 +702,7 @@ exports.authorView = ({
       div(
         a({ href: `/likes/${encodeURIComponent(feedId)}` }, i18n.viewLikes),
         span(nbsp, relationshipText),
-        contactForm,
+        ...contactForms,
         relationship === null
           ? a({ href: `/profile/edit` }, nbsp, i18n.editProfile)
           : null


### PR DESCRIPTION
Problem: We have a way to follow and unfollow, but there's no way to
block or unblock. Also if you go to the profile of a blocked peer, their
posts still show up.

Solution: Add block and unblock and hide messages from blocked peers on
their profile page.

Fixes: https://github.com/fraction/oasis/issues/370