### PR TITLE
Show who liked content on hover

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -410,6 +410,25 @@ section > footer > div > form > button.liked {
   color: var(--red);
 }
 
+section > footer > div > form > button.like > span.liked-by {
+  display: none
+}
+
+section > footer > div > form > button.like:hover {
+  background-color: inherit;
+}
+
+section > footer > div > form > button.like:hover > span.liked-by {
+  display: block;
+  position: absolute;
+  max-width: 300px;
+  padding: 15px;
+  background-color: var(--base07);
+  color: var(--base00);
+  border-radius: var(--common-radius);
+  z-index: 5;
+}
+
 label {
   display: block;
   margin: 0;

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -411,7 +411,7 @@ section > footer > div > form > button.liked {
 }
 
 section > footer > div > form > button.like > span.liked-by {
-  display: none
+  display: none;
 }
 
 section > footer > div > form > button.like:hover {

--- a/src/models.js
+++ b/src/models.js
@@ -469,7 +469,9 @@ module.exports = ({ cooler, isPublic }) => {
           .map(([key]) => key);
 
         // get an array of voter names, for display on hover
-        const pendingVoterNames = voters.map((author) => models.about.name(author));
+        const pendingVoterNames = voters.map((author) =>
+          models.about.name(author)
+        );
         const voterNames = await Promise.all(pendingVoterNames);
 
         const pendingName = models.about.name(msg.value.author);
@@ -1056,13 +1058,12 @@ module.exports = ({ cooler, isPublic }) => {
 
               const adjustedObj = Object.entries(obj).reduce(
                 (acc, [author, values]) => {
-                  // If the author liked their own content, ignore the vote
                   if (author === myFeedId) {
                     return acc;
                   }
 
-                  // The value of a users vote is 1 / (1 + total votes), the 
-                  // more a user votes, the less weight is given to each vote. 
+                  // The value of a users vote is 1 / (1 + total votes), the
+                  // more a user votes, the less weight is given to each vote.
 
                   const entries = Object.entries(values);
                   const total = 1 + Math.log(entries.length);

--- a/src/models.js
+++ b/src/models.js
@@ -468,6 +468,10 @@ module.exports = ({ cooler, isPublic }) => {
           .filter(([, value]) => value === 1)
           .map(([key]) => key);
 
+        // get an array of voter names, for display on hover
+        const pendingVoterNames = voters.map((author) => models.about.name(author));
+        const voterNames = await Promise.all(pendingVoterNames);
+
         const pendingName = models.about.name(msg.value.author);
         const pendingAvatarMsg = models.about.image(msg.value.author);
 
@@ -545,7 +549,7 @@ module.exports = ({ cooler, isPublic }) => {
           lodash.set(msg, "value.meta.postType", "mystery");
         }
 
-        lodash.set(msg, "value.meta.votes", voters);
+        lodash.set(msg, "value.meta.votes", voterNames);
         lodash.set(msg, "value.meta.voted", voters.includes(myFeedId));
 
         return msg;
@@ -1052,9 +1056,13 @@ module.exports = ({ cooler, isPublic }) => {
 
               const adjustedObj = Object.entries(obj).reduce(
                 (acc, [author, values]) => {
+                  // If the author liked their own content, ignore the vote
                   if (author === myFeedId) {
                     return acc;
                   }
+
+                  // The value of a users vote is 1 / (1 + total votes), the 
+                  // more a user votes, the less weight is given to each vote. 
 
                   const entries = Object.entries(values);
                   const total = 1 + Math.log(entries.length);

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -474,7 +474,7 @@ const post = ({ msg, aside = false }) => {
 
   const maxLikedNameLength = 16;
   const maxLikedNames = 20;
-  
+
   const likedBy = msg.value.meta.votes
     .slice(0, maxLikedNames)
     .map((name) => name.slice(0, maxLikedNameLength))
@@ -571,11 +571,13 @@ const post = ({ msg, aside = false }) => {
               class: likeButton.class,
             },
             `❤ ${likeCount}`,
-            span({
-              class: "liked-by",
-            },
-            `Liked by ${likedBy}`)
-          ),
+            span(
+              {
+                class: "liked-by",
+              },
+              `Liked by ${likedBy}`
+            )
+          )
         ),
         a({ href: url.comment }, i18n.comment),
         isPrivate || isRoot || isFork

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -467,10 +467,18 @@ const post = ({ msg, aside = false }) => {
     typeof msg.value.content.contentWarning === "string";
 
   const likeButton = msg.value.meta.voted
-    ? { value: 0, class: "liked" }
-    : { value: 1, class: null };
+    ? { value: 0, class: "like liked" }
+    : { value: 1, class: "like" };
 
   const likeCount = msg.value.meta.votes.length;
+
+  const maxLikedNameLength = 16;
+  const maxLikedNames = 20;
+  
+  const likedBy = msg.value.meta.votes
+    .slice(0, maxLikedNames)
+    .map((name) => name.slice(0, maxLikedNameLength))
+    .join(", ");
 
   const messageClasses = ["post"];
 
@@ -562,8 +570,12 @@ const post = ({ msg, aside = false }) => {
               value: likeButton.value,
               class: likeButton.class,
             },
-            `❤ ${likeCount}`
-          )
+            `❤ ${likeCount}`,
+            span({
+              class: "liked-by",
+            },
+            `Liked by ${likedBy}`)
+          ),
         ),
         a({ href: url.comment }, i18n.comment),
         isPrivate || isRoot || isFork


### PR DESCRIPTION
- Adds a hover popup that shows the names of everyone who liked a post
when hovering of the heart.
- Add new call to post.get that retrieves the names of all voters and
returns them instead of their ID's.

I added the extra "like" class to make the css more specific, didn't want to apply the hover effect to all buttons. 

## What's the problem you solved?

Fixes #256 

## What solution are you recommending?

A simple hover on all hearts that shows who liked something. Here's how it looks for a post with a few likes:

![2020-03-30-235113_468x288_scrot](https://user-images.githubusercontent.com/525534/77996293-35434d80-72e2-11ea-88a7-a4224c96ab10.png)


And a post with many likes:

![2020-03-30-235105_416x306_scrot](https://user-images.githubusercontent.com/525534/77996306-3a080180-72e2-11ea-8856-314bbf15fafd.png)

Happy to make changes to CSS to fit Oasis better, I'm not the best designer. 
