### PR TITLE
Updates query for threads

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -936,12 +936,22 @@ module.exports = ({ cooler, isPublic }) => {
 
       const myFeedId = ssb.id;
 
-      const options = configure({
-        type: "post",
-        private: false,
-      });
-
-      const source = ssb.messagesByType(options);
+      const source = ssb.query.read(
+        configure({
+          query: [
+            {
+              $filter: {
+                value: {
+                  timestamp: { $lte: Date.now() },
+                  content: {
+                    type: "post",
+                  },
+                },
+              },
+            },
+          ],
+        })
+      );
 
       const messages = await new Promise((resolve, reject) => {
         pull(


### PR DESCRIPTION
## What's the problem you solved?
Previous query incorrectly pulled and sorted posts, often showing years
old posts from newly followed people.

## What solution are you recommending?
This now behaves more consistently
as "recent threads from people in your extended network".
