### PR TITLE
Fix z-index on sticky header

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -342,6 +342,7 @@ section > header {
   padding-top: var(--milli);
   position: sticky;
   top: 0;
+  z-index: 1;
 }
 
 section > header > div {


### PR DESCRIPTION
##  What's the problem you solved?
<img width="560" alt="Screen Shot 2020-03-31 at 11 05 18 AM" src="https://user-images.githubusercontent.com/1012017/78042167-a8c77800-733f-11ea-8377-afe4cdb166d7.png">

## What solution are you recommending?
<img width="557" alt="Screen Shot 2020-03-31 at 11 05 26 AM" src="https://user-images.githubusercontent.com/1012017/78042218-b7159400-733f-11ea-8fb6-cc33b3368b84.png">