### PR TITLE
Show liked-by in title attr, handle many likes

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -411,25 +411,6 @@ section > footer > div > form > button.liked {
   color: var(--red);
 }
 
-section > footer > div > form > button.like > span.liked-by {
-  display: none;
-}
-
-section > footer > div > form > button.like:hover {
-  background-color: inherit;
-}
-
-section > footer > div > form > button.like:hover > span.liked-by {
-  display: block;
-  position: absolute;
-  max-width: 300px;
-  padding: 15px;
-  background-color: var(--base07);
-  color: var(--base00);
-  border-radius: var(--common-radius);
-  z-index: 5;
-}
-
 label {
   display: block;
   margin: 0;

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -475,15 +475,16 @@ const post = ({ msg, aside = false }) => {
   const maxLikedNameLength = 16;
   const maxLikedNames = 16;
 
-  let likedBy = msg.value.meta.votes
+  const likedByNames = msg.value.meta.votes
     .slice(0, maxLikedNames)
     .map((name) => name.slice(0, maxLikedNameLength))
     .join(", ");
 
-  if (likeCount > maxLikedNames) {
-    const extraLikes = likeCount - maxLikedNames;
-    likedBy += ` +${extraLikes} more`;
-  }
+  const additionalLikesMessage =
+    likeCount > maxLikedNames ? `+${likeCount - maxLikedNames} more` : ``;
+
+  const likedByMessage =
+    likeCount > 0 ? `Liked by ${likedByNames} ${additionalLikesMessage}` : null;
 
   const messageClasses = ["post"];
 
@@ -574,7 +575,7 @@ const post = ({ msg, aside = false }) => {
               type: "submit",
               value: likeButton.value,
               class: likeButton.class,
-              title: `Liked by ${likedBy}`,
+              title: likedByMessage,
             },
             `❤ ${likeCount}`
           )

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -467,18 +467,23 @@ const post = ({ msg, aside = false }) => {
     typeof msg.value.content.contentWarning === "string";
 
   const likeButton = msg.value.meta.voted
-    ? { value: 0, class: "like liked" }
-    : { value: 1, class: "like" };
+    ? { value: 0, class: "liked" }
+    : { value: 1, class: null };
 
   const likeCount = msg.value.meta.votes.length;
 
   const maxLikedNameLength = 16;
-  const maxLikedNames = 20;
+  const maxLikedNames = 16;
 
-  const likedBy = msg.value.meta.votes
+  let likedBy = msg.value.meta.votes
     .slice(0, maxLikedNames)
     .map((name) => name.slice(0, maxLikedNameLength))
     .join(", ");
+
+  if (likeCount > maxLikedNames) {
+    const extraLikes = likeCount - maxLikedNames;
+    likedBy += ` +${extraLikes} more`;
+  }
 
   const messageClasses = ["post"];
 
@@ -569,14 +574,9 @@ const post = ({ msg, aside = false }) => {
               type: "submit",
               value: likeButton.value,
               class: likeButton.class,
+              title: `Liked by ${likedBy}`,
             },
-            `❤ ${likeCount}`,
-            span(
-              {
-                class: "liked-by",
-              },
-              `Liked by ${likedBy}`
-            )
+            `❤ ${likeCount}`
           )
         ),
         a({ href: url.comment }, i18n.comment),


### PR DESCRIPTION
- Instead of having a custom on hover effect, just add the Liked by
message to the title of the heart.
- When there are > 16 likes on a post, show +X more to convey this to
users.
- Removed the old css code and the 'like' class on the button, reverting CSS changes in #377 

## What's the problem you solved?

Fixed #380 

Making the liked-by popup more accessible to non-mouse users. Also better for future maintainence as it doesn't require additional CSS or classes. 

## What solution are you recommending?

Showing liked-by via title attribute, as described in #380 


