### PR TITLE
Fix footer button hover background

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -202,8 +202,8 @@ button:hover {
   background-color: var(--fg-light);
 }
 
-section > div > footer > form > button:hover,
-section > div > footer > form > button:focus {
+section > footer > div > form > button:hover,
+section > footer > div > form > button:focus {
   background-color: transparent;
 }
 


### PR DESCRIPTION
Problem: Footer buttons have the normal button background hover state
that makes them difficult to read. This was meant to be fixed in another
PR but I think I got the CSS order wrong.

Solution: Reorder the CSS hierarchy to fix the bug. For real this time.

Fixes: #357 