### PR TITLE
Fix config bug

### DIFF
--- a/src/ssb.js
+++ b/src/ssb.js
@@ -57,7 +57,7 @@ const rawConnect = (options) =>
 
 let handle;
 
-const createConnection = (config) => {
+const createConnection = (customConfig) => {
   handle = new Promise((resolve) => {
     rawConnect({ remote })
       .then((ssb) => {
@@ -80,11 +80,15 @@ const createConnection = (config) => {
 
             log("Connection attempts to existing Scuttlebutt services failed");
             log("Starting Scuttlebutt service");
-            const server = flotilla(config);
-            server(config);
+
+            // Start with the default SSB-Config object.
+            const server = flotilla(ssbConfig);
+            // Adjust with `customConfig`, which declares further preferences.
+            server(customConfig);
+
             const inProgress = {};
             const maxHops = lodash.get(
-              config,
+              ssbConfig,
               "friends.hops",
               lodash.get(ssbConfig, "friends.hops", 0)
             );


### PR DESCRIPTION
Problem: I made a bad merge in 2836c80 which broke the server in some
environments. I had issues running the globablly installed binary,
whereas `npm start` seemed to work fine. Anyway, there's an error about
some missing config options because we weren't importing SSB-Config into
the server configuration. Instead, the full config was just:

```json
{ "conn": { "autostart": true } }
```

This lacks important properties like `shs`, which means that the server
can't start. Fun!

Solution: Pass SSB-Config first and then overlay our custom config on
top. I've also added comments and changed the variable names so that
this is harder to miss in the future.