### PR TITLE
Use longer test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "nodemon --inspect src/index.js --debug --no-open",
     "fix": "common-good fix",
     "start": "node src/index.js",
-    "test": "tap --timeout 240 && common-good check --dependency-check-suffix '-i changelog-version -i mkdirp -i nodemon -i stylelint-config-recommended'",
+    "test": "tap --timeout 600 && common-good check --dependency-check-suffix '-i changelog-version -i mkdirp -i nodemon -i stylelint-config-recommended'",
     "preversion": "npm test",
     "version": "mv docs/CHANGELOG.md ./ && changelog-version && mv CHANGELOG.md docs/ && git add CHANGELOG.md"
   },

--- a/test/lifecycle.js
+++ b/test/lifecycle.js
@@ -6,6 +6,8 @@ process.argv.push("--no-open", "--offline");
 const app = require("../src");
 const tap = require("tap");
 
+tap.setTimeout(0);
+
 tap.test("lifecycle", (t) => {
   t.plan(1);
   t.ok(app, "app exists");


### PR DESCRIPTION
Problem: I think that on Windows our test is hitting a timeout but I'm
not sure why. It could either be the global timeout (from
`package.json`) or the file-specific timeout (from `tap.setTimeout()`).

Solution: Increment the global timeout to 10 minutes and the
file-specific timeout to infinity.

---

I :heart: intermittent test failures.