### PR TITLE
Start SSB service immediately instead of waiting

### DIFF
--- a/src/ssb.js
+++ b/src/ssb.js
@@ -193,18 +193,13 @@ module.exports = ({ offline }) => {
     },
   };
 
-  // Important: This ensures that we have an SSB connection as soon as Oasis
-  // starts. If we don't do this, then we don't even attempt an SSB connection
-  // until we receive our first HTTP request.
-  ensureConnection(customConfig);
-
   let clientHandle;
 
   /**
    * This is "cooler", a tiny interface for opening or reusing an instance of
    * SSB-Client.
    */
-  return {
+  const cooler = {
     open() {
       // This has interesting behavior that may be unexpected.
       //
@@ -239,4 +234,11 @@ module.exports = ({ offline }) => {
       }
     },
   };
+
+  // Important: This ensures that we have an SSB connection as soon as Oasis
+  // starts. If we don't do this, then we don't even attempt an SSB connection
+  // until we receive our first HTTP request.
+  cooler.open();
+
+  return cooler;
 };

--- a/src/ssb.js
+++ b/src/ssb.js
@@ -215,7 +215,7 @@ module.exports = ({ offline }) => {
           ensureConnection(customConfig).then((ssb) => {
             clientHandle = ssb;
             if (closing) {
-              ssb.close();
+              cooler.close();
               reject(new Error("Closing Oasis"));
             } else {
               resolve(ssb);

--- a/src/ssb.js
+++ b/src/ssb.js
@@ -193,6 +193,11 @@ module.exports = ({ offline }) => {
     },
   };
 
+  // Important: This ensures that we have an SSB connection as soon as Oasis
+  // starts. If we don't do this, then we don't even attempt an SSB connection
+  // until we receive our first HTTP request.
+  ensureConnection(customConfig);
+
   let clientHandle;
 
   /**


### PR DESCRIPTION
Problem: During a refactor the SSB connection management was changed to
be more conservative, so it only ensures that we have a connection once
the server is started. This isn't good, because it means `oasis
--no-open` no longer starts an SSB service in the background.

Solution: Run `ensureConnection()` to ensure that we have a connection
to the SSB service regardless of regardless of whether we've received
any requests over HTTP.

---

See: `%feSvhuLLa8vA475+k1Z9ZWEAHvNhYTT1H4wlpcoGEYw=.sha256`