### PR TITLE
Add --allow-host CLI flag for for proxy use-case

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -31,6 +31,12 @@ module.exports = (presets, defaultConfigFile) =>
       default: _.get(presets, "host", "localhost"),
       type: "string",
     })
+    .options("allow-host", {
+      describe:
+        "Extra hostname to be whitelisted (useful when running behind a proxy)",
+      default: _.get(presets, "host", null),
+      type: "string",
+    })
     .options("port", {
       describe: "Port for web app to listen on",
       default: _.get(presets, "port", 3000),

--- a/src/http.js
+++ b/src/http.js
@@ -5,10 +5,10 @@ const mount = require("koa-mount");
 
 /**
  * @type function
- * @param {{ host: string, port: number, middleware: any[] }} input
+ * @param {{ host: string, port: number, middleware: any[], allowHost: string | null }} input
  * @return function
  */
-module.exports = ({ host, port, middleware }) => {
+module.exports = ({ host, port, middleware, allowHost }) => {
   const assets = new Koa();
   assets.use(koaStatic(path.join(__dirname, "assets")));
 
@@ -124,6 +124,10 @@ module.exports = ({ host, port, middleware }) => {
     if (typeof address === "string") {
       // This shouldn't happen, but TypeScript was complaining about it.
       throw new Error("HTTP server should never bind to Unix socket");
+    }
+
+    if (allowHost !== null) {
+      validHosts.push(allowHost);
     }
 
     validHosts.push(address.address);

--- a/src/index.js
+++ b/src/index.js
@@ -807,7 +807,8 @@ const middleware = [
   routes,
 ];
 
-const app = http({ host, port, middleware });
+const { allowHost } = config;
+const app = http({ host, port, middleware, allowHost });
 
 // HACK: This lets us close the database once tests finish.
 // If we close the database after each test it throws lots of really fun "parent


### PR DESCRIPTION
Problem: When proxying Oasis, the CSRF + DNS rebind security precautions
will respond with HTTP 400 if you use a hostname that Oasis doesn't
know about. For example, if Oasis is listening on `localhost` and you
use Caddy/Nginx/etc to proxy that to `oasis.example.com`, then Oasis
will see GET requests as DNS rebind attacks and POST requests as CSRF
attacks.

Solution: Add `--allow-host` command-line flag so that you can
`--allow-host oasis.example.com` and ensure that the host is allowed by
the security measures.