### PR TITLE
Replace setImmediate() with .on('listening')

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -117,8 +117,7 @@ module.exports = ({ host, port, middleware, allowHost }) => {
 
   const server = app.listen({ host, port });
 
-  // `server.address()` returns null unless you wait until the next tick.
-  setImmediate(() => {
+  server.on("listening", () => {
     const address = server.address();
 
     if (typeof address === "string") {


### PR DESCRIPTION
Problem: Unfortunately `setImmediate()` doesn't actually ensure that
`server !== null`, so we can get fun race condition errors that have
been reported on Windows.

Solution: Replace `setImmediate()` hack with event emitter that actually
ensures that the server is listening (and hopefully isn't `null)`.

Fixes: https://github.com/fraction/oasis/issues/401