### PR TITLE
Introduces sync endpoint

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -52,6 +52,7 @@
     "systemctl",
     "systemd",
     "unfollow",
+    "unstage",
     "unikitty",
     "zeromq"
   ]

--- a/.cspell.json
+++ b/.cspell.json
@@ -52,7 +52,6 @@
     "systemctl",
     "systemd",
     "unfollow",
-    "unstage",
     "unikitty",
     "zeromq"
   ]

--- a/src/index.js
+++ b/src/index.js
@@ -755,6 +755,10 @@ router
     await meta.connStop();
     ctx.redirect("/settings");
   })
+  .post("/settings/conn/sync", koaBody(), async (ctx) => {
+    await meta.sync();
+    ctx.redirect("/settings");
+  })
   .post("/settings/conn/restart", koaBody(), async (ctx) => {
     await meta.connRestart();
     ctx.redirect("/settings");

--- a/src/index.js
+++ b/src/index.js
@@ -514,7 +514,7 @@ router
     const theme = ctx.cookies.get("theme") || config.theme;
     const getMeta = async ({ theme }) => {
       const status = await meta.status();
-      const peers = await meta.peers();
+      const peers = await meta.connectedPeers();
       const peersWithNames = await Promise.all(
         peers.map(async ([key, value]) => {
           value.name = await about.name(value.key);

--- a/src/models.js
+++ b/src/models.js
@@ -334,7 +334,6 @@ module.exports = ({ cooler, isPublic }) => {
       await new Promise((r) => setTimeout(r, 1000));
       const originalProgress = await ssb.progress();
 
-
       const waitForPeers = async () => {
         const peers = await models.meta.connectedPeers();
         if (peers && peers.length) {
@@ -380,7 +379,8 @@ module.exports = ({ cooler, isPublic }) => {
           }
 
           if (inProgress.indexes.target === lastCheckProgress.indexes.target) {
-            let total = inProgress.indexes.target - originalProgress.indexes.target;
+            let total =
+              inProgress.indexes.target - originalProgress.indexes.target;
             debug("Nothing more. We out.");
             debug("Downloaded %s objects", total);
           }

--- a/src/models.js
+++ b/src/models.js
@@ -275,6 +275,7 @@ module.exports = ({ cooler, isPublic }) => {
     peers: async () => {
       const ssb = await cooler.open();
       const peersSource = await ssb.conn.peers();
+
       return new Promise((resolve, reject) => {
         pull(
           peersSource,
@@ -339,7 +340,6 @@ module.exports = ({ cooler, isPublic }) => {
       };
 
       // Let's wait a second for things to be ready
-      // before we check in on the current state
       await delay(1000);
       const originalProgress = await ssb.progress();
 
@@ -353,10 +353,6 @@ module.exports = ({ cooler, isPublic }) => {
         }
       };
 
-      // By checking for peers being connected first
-      // we can be more confident about whether there
-      // is no available people to sync with or nothing
-      // to sync at all
       debug("Waiting for peers to connect...");
       await waitForPeers();
 
@@ -398,8 +394,7 @@ module.exports = ({ cooler, isPublic }) => {
 
       await getProgress(originalProgress, false);
 
-      // conn.stop stops the sceduler but can leave some connecting
-      // peers in limbo so we'll disconnect manuallly first
+      // conn.stop stops the scheduler but can leave connecting peers in limbo
       await models.meta.disconnect();
       await models.meta.connStop();
     },

--- a/src/models.js
+++ b/src/models.js
@@ -291,9 +291,9 @@ module.exports = ({ cooler, isPublic }) => {
       const peers = await models.meta.peers();
       return peers.filter(([address, data]) => {
         if (data.state === "connected") {
-          return [address, data]
+          return [address, data];
         }
-      })
+      });
     },
     disconnect: async () => {
       const ssb = await cooler.open();
@@ -335,8 +335,8 @@ module.exports = ({ cooler, isPublic }) => {
 
       let syncDelay = 5000; //ms
       const delay = (ms) => {
-        return new Promise(resolve => setTimeout(resolve, ms));
-      }
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      };
 
       // Let's wait a second for things to be ready
       // before we check in on the current state

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -149,6 +149,7 @@ const i18n = {
     startNetworking: "Start networking",
     stopNetworking: "Stop networking",
     restartNetworking: "Restart networking",
+    sync: "Connect and Sync",
     indexes: "Indexes",
     invites: "Invites",
     invitesDescription:

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -769,10 +769,16 @@ exports.settingsView = ({ status, peers, theme, themeNames, version }) => {
     button({ type: "submit" }, i18n.stopNetworking)
   );
 
+  const syncButton = form(
+    { action: "/settings/conn/sync", method: "post" },
+    button({ type: "submit" }, i18n.sync)
+  );
+
   const connButtons = div({ class: "form-button-group" }, [
     startButton,
     restartButton,
     stopButton,
+    syncButton,
   ]);
 
   const peerList = (peers || [])


### PR DESCRIPTION
## What's the problem you solved?

Constant network activity of connecting to peers and streaming of data can be really busy and distracting. "Sync" allows you to keep Oasis running in offline mode and sync when you want to get new stuff. Sync can be expanded upon in the future to be more useful when calling from a script.

Relates to #354. 

## What solution are you recommending?

When clicking "Connect and Sync" in settings, Oasis starts the connection scheduler, waits until you're connected to peers, waits for items to download, and then disconnects from peers.

This is best used when running Oasis in offline mode. It's basically useless in "normal" mode and will actually stop the connection scheduler and disconnect you from connected peers, which may be unexpected if you're not already offline. This could probably be improved upon.