### PR TITLE
Add Français (FR) to the language drop-down

### DIFF
--- a/src/views/index.js
+++ b/src/views/index.js
@@ -820,7 +820,7 @@ exports.settingsView = ({ status, peers, theme, themeNames, version }) => {
     })
   );
 
-  const languageOption = (shortName, longName) =>
+  const languageOption = (longName, shortName) =>
     shortName === selectedLanguage
       ? option({ value: shortName, selected: true }, longName)
       : option({ value: shortName }, longName);
@@ -855,11 +855,13 @@ exports.settingsView = ({ status, peers, theme, themeNames, version }) => {
       form(
         { action: "/language", method: "post" },
         select({ name: "language" }, [
+          // Languages are sorted alphabetically by their 'long name'.
           /* cspell:disable */
-          languageOption("en", "English"),
-          languageOption("es", "Español"),
-          languageOption("it", "Italiano"),
-          languageOption("de", "Deutsch"),
+          languageOption("Deutsch", "de"),
+          languageOption("English", "en"),
+          languageOption("Español", "es"),
+          languageOption("Français", "fr"),
+          languageOption("Italiano", "it"),
           /* cspell:enable */
         ]),
         button({ type: "submit" }, i18n.setLanguage)


### PR DESCRIPTION
Problem: The FR translation is added in `i18n.js` but it's not available
in the drop-down language selection menu.

Solution: Add it to the menu and ensure that the menu is sorted
alphabetically by the name of the language.