### PR TITLE
Fix allow-host preset not working correctly

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -34,7 +34,7 @@ module.exports = (presets, defaultConfigFile) =>
     .options("allow-host", {
       describe:
         "Extra hostname to be whitelisted (useful when running behind a proxy)",
-      default: _.get(presets, "host", null),
+      default: _.get(presets, "allow-host", null),
       type: "string",
     })
     .options("port", {


### PR DESCRIPTION
Problem: The preset for allow-host is coming from "host".

Solution: Make the preset for allow-host come from "allow-host".