### PR TITLE
Rename "reply" to "subtopic"

### DIFF
--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -54,7 +54,7 @@ const i18n = {
     settings: "Settings",
     // post actions
     comment: "Comment",
-    reply: "Reply",
+    subtopic: "Subtopic",
     json: "JSON",
     // relationships
     unfollow: "Unfollow",
@@ -80,7 +80,7 @@ const i18n = {
     ],
     commentWarning: [
       " Comments cannot be edited or deleted. To respond to an individual message, select ",
-      strong("reply"),
+      strong("subtopic"),
       " instead.",
     ],
     commentPublic: "public",
@@ -115,10 +115,10 @@ const i18n = {
     ],
     publishCustom: "Publish custom",
 
-    replyLabel: ({ markdownUrl }) => [
-      "Write a ",
-      strong("public reply"),
-      " to this message with ",
+    subtopicLabel: ({ markdownUrl }) => [
+      "Create a ",
+      strong("public subtopic"),
+      " of this message with ",
       a({ href: markdownUrl }, "Markdown"),
       ". Messages cannot be edited or deleted. To respond to an entire thread, select ",
       strong("comment"),
@@ -162,9 +162,9 @@ const i18n = {
       " commented on ",
       a({ href: parentUrl }, " thread"),
     ],
-    replyDescription: ({ parentUrl }) => [
-      " replied to ",
-      a({ href: parentUrl }, " message"),
+    subtopicDescription: ({ parentUrl }) => [
+      " created a subtopic from ",
+      a({ href: parentUrl }, " a message"),
     ],
     mysteryDescription: "posted a mysterious message",
     // misc

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -314,21 +314,18 @@ const post = ({ msg, aside = false }) => {
     parent: `/thread/${encoded.parent}#${encoded.parent}`,
     avatar: msg.value.meta.author.avatar.url,
     json: `/json/${encoded.key}`,
-    reply: `/reply/${encoded.key}`,
+    subtopic: `/subtopic/${encoded.key}`,
     comment: `/comment/${encoded.key}`,
   };
 
   const isPrivate = Boolean(msg.value.meta.private);
   const isRoot = msg.value.content.root == null;
-  const isFork = msg.value.meta.postType === "reply";
+  const isFork = msg.value.meta.postType === "subtopic";
   const hasContentWarning =
     typeof msg.value.content.contentWarning === "string";
   const isThreadTarget = Boolean(
     lodash.get(msg, "value.meta.thread.target", false)
   );
-
-  // TODO: I think this is actually true for both replies and comments.
-  const isReply = Boolean(lodash.get(msg, "value.meta.thread.reply", false));
 
   const { name } = msg.value.meta.author;
   const timeAgo = msg.value.meta.timestamp.received.since.replace("~", "");
@@ -368,16 +365,11 @@ const post = ({ msg, aside = false }) => {
     messageClasses.push("thread-target");
   }
 
-  if (isReply) {
-    // True for comments too, I think
-    messageClasses.push("reply");
-  }
-
   // TODO: Refactor to stop using strings and use constants/symbols.
   const postOptions = {
     post: null,
     comment: i18n.commentDescription({ parentUrl: url.parent }),
-    reply: i18n.replyDescription({ parentUrl: url.parent }),
+    subtopic: i18n.subtopicDescription({ parentUrl: url.parent }),
     mystery: i18n.mysteryDescription,
   };
 
@@ -453,7 +445,7 @@ const post = ({ msg, aside = false }) => {
         a({ href: url.comment }, i18n.comment),
         isPrivate || isRoot || isFork
           ? null
-          : a({ href: url.reply }, nbsp, i18n.reply),
+          : a({ href: url.subtopic }, nbsp, i18n.subtopic),
         a({ href: url.json }, nbsp, i18n.json)
       ),
       br()
@@ -629,13 +621,13 @@ exports.commentView = async ({ messages, myFeedId, parentMessage }) => {
   const isPrivate = parentMessage.value.meta.private;
 
   const publicOrPrivate = isPrivate ? i18n.commentPrivate : i18n.commentPublic;
-  const maybeReplyText = isPrivate ? [null] : i18n.commentWarning;
+  const maybeSubtopicText = isPrivate ? [null] : i18n.commentWarning;
 
   return template(
     messageElements,
     p(
       ...i18n.commentLabel({ publicOrPrivate, markdownUrl }),
-      ...maybeReplyText
+      ...maybeSubtopicText
     ),
     form(
       { action, method },
@@ -971,8 +963,8 @@ exports.threadsView = ({ messages }) => {
   });
 };
 
-exports.replyView = async ({ messages, myFeedId }) => {
-  const replyForm = `/reply/${encodeURIComponent(
+exports.subtopicView = async ({ messages, myFeedId }) => {
+  const subtopicForm = `/subtopic/${encodeURIComponent(
     messages[messages.length - 1].key
   )}`;
 
@@ -995,9 +987,9 @@ exports.replyView = async ({ messages, myFeedId }) => {
 
   return template(
     messageElements,
-    p(i18n.replyLabel({ markdownUrl })),
+    p(i18n.subtopicLabel({ markdownUrl })),
     form(
-      { action: replyForm, method: "post" },
+      { action: subtopicForm, method: "post" },
       textarea(
         {
           autofocus: true,
@@ -1010,7 +1002,7 @@ exports.replyView = async ({ messages, myFeedId }) => {
         {
           type: "submit",
         },
-        i18n.reply
+        i18n.subtopic
       )
     )
   );


### PR DESCRIPTION
Problem: The words "comment" and "reply" are super ambiguous, but
renaming them is hard.

Solution: I think "subtopic" captures the sentiment well, and makes it
clear that you're leaving the current topic to start a new topic (rather
than just replying to an individual message).

Fixes: #27 