### PR TITLE
Refactor Docker example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+.git

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,16 +1,25 @@
-FROM node:12-alpine
-RUN apk add --update --no-cache libtool autoconf automake alpine-sdk python3
-RUN mkdir /app
-WORKDIR /app
-ADD package.json .
-ADD package-lock.json .
+FROM node:lts
+
+# Ensure that the ~/.ssb directory is persistent and owned by the 'node' user.
+RUN mkdir /home/node/.ssb && chown node:node /home/node/.ssb
+VOLUME /home/node/.ssb
+
+# Don't run as root.
+USER node
+
+# Create app directory and use it.
+RUN mkdir /home/node/app
+WORKDIR /home/node/app
+
+# Add dependency metadata and install dependencies.
+ADD package.json package-lock.json ./
 RUN npm ci
-ADD . ./
-EXPOSE 3000
-EXPOSE 8008
-VOLUME /root/.ssb
-ADD https://github.com/just-containers/s6-overlay/releases/download/v1.21.8.0/s6-overlay-amd64.tar.gz /tmp/
-RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C /
-RUN mkdir /etc/services.d/oasis/
-RUN printf "#!/usr/bin/execlineb -P\n/usr/local/bin/node /app/src/index.js --host 0.0.0.0 --open false" >> /etc/services.d/oasis/run
-ENTRYPOINT ["/init"]
+
+# Add the rest of the source code.
+ADD ./ ./
+
+# Expose ports for Oasis and SSB replication.
+EXPOSE 3000 8008
+
+# Listen on the container's public interfaces but allow 'localhost' connections.
+CMD ["node", ".", "--host", "0.0.0.0", "--allow-host", "localhost"]

--- a/docs/with-docker.md
+++ b/docs/with-docker.md
@@ -14,5 +14,7 @@ docker volume create ssb
 ## Run
 
 ```
-docker run --mount source=ssb,target=/root/.ssb --publish 3000:3000 --rm oasis
+docker run --mount source=ssb,target=/home/node/.ssb --publish 127.0.0.0:3000:3000 --rm oasis
 ```
+
+You should now be able to open http://localhost:3000 in your browser.


### PR DESCRIPTION
Problem: The Docker example was using Alpine with the Tini dependency
and some neat custom stuff, but it wasn't super clear to understand
everything that was going on. It was also slow because lots of stuff was
compiling from source.

Solution: Replace neat custom stuff with boring defaults for clarity and
much faster builds.