### PR TITLE
Improve wrapping of sticky section header

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -332,7 +332,6 @@ section {
 section > header {
   background: var(--bg);
   color: var(--fg-status);
-  height: var(--line);
   margin-bottom: calc(-1 * var(--size--1));
   margin-top: calc(-1 * var(--size--1));
   padding-bottom: var(--size--1);
@@ -342,9 +341,14 @@ section > header {
   z-index: 1;
 }
 
+.author-action {
+  flex-grow: 1;
+}
+
 section > header > div {
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 section header a > .avatar {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -409,9 +409,9 @@ const post = ({ msg, aside = false }) => {
             { href: url.author },
             img({ class: "avatar", src: url.avatar, alt: "" }),
             name
-          ),
-          postOptions[msg.value.meta.postType]
+          )
         ),
+        span({ class: "author-action" }, postOptions[msg.value.meta.postType]),
         span(
           { class: "time" },
           isPrivate ? "🔒" : null,


### PR DESCRIPTION
## What's the problem you solved?

Section headers were poorly wrapping on tiny screens.

[Before Screenshot](https://user-images.githubusercontent.com/1012017/81691662-2bf1e880-942b-11ea-947d-1587c437012b.png) | [After Screenshot](https://user-images.githubusercontent.com/1012017/81691688-3318f680-942b-11ea-8303-ea444f49cc6f.png)

## What solution are you recommending?

Some flex options to fill space and wrap.
