### PR TITLE
Adds visual separator between different threads

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -131,6 +131,13 @@ section header a {
   margin-left: var(--size--2);
 }
 
+/* For use with elements specific for
+ * rendering in a text browser and intended
+ * to be hidden in a graphical browser. */
+.text-browser {
+  display: none;
+}
+
 section > footer > div > a,
 section > footer > div > form > button {
   color: var(--fg-status);

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -20,6 +20,7 @@ const {
   h2,
   head,
   header,
+  hr,
   html,
   img,
   input,
@@ -457,8 +458,10 @@ const post = ({ msg, aside = false }) => {
     )
   );
 
+  const threadSeparator = [div({ class: "text-browser" }, hr(), br())];
+
   if (aside) {
-    return [fragment, postAside(msg)];
+    return [fragment, postAside(msg), isRoot ? threadSeparator : null];
   } else {
     return fragment;
   }


### PR DESCRIPTION
## What's the problem you solved?

When using a text browser (w3m in my case), it's hard to distinguish between different threads in the Summaries and Threads view. The indentation and CSS-based left border on comments and subtopics don't render in text-based browsers.

There was very little visual distinction when the comments on a thread ended and when the next thread begins:

<img width="1486" alt="Screen Shot 2020-05-13 at 2 30 29 PM" src="https://user-images.githubusercontent.com/1012017/81851044-de5aa600-9526-11ea-8995-377fc8008a8a.png">

## What solution are you recommending?

Introduce a `<hr>` after a thread. This is determined by when a message `isRoot` and has `aside`.

<img width="1486" alt="Screen Shot 2020-05-13 at 2 30 07 PM" src="https://user-images.githubusercontent.com/1012017/81851136-fdf1ce80-9526-11ea-8cd2-d535330a56eb.png">

The `text-browser` class is added to `display: none;` in CSS. In effect, this PR makes no change to graphical browsers and only displays the horizontal rule when browsers that don't use CSS. This seems to be a better approach than my last attempt (#364).