### PR TITLE
Fix broken Profile Edit

### DIFF
--- a/src/views/index.js
+++ b/src/views/index.js
@@ -469,6 +469,7 @@ const post = ({ msg, aside = false }) => {
 
 exports.editProfileView = ({ name, description }) =>
   template(
+    i18n.editProfile,
     section(
       h1(i18n.editProfile),
       p(i18n.editProfileDescription),


### PR DESCRIPTION
## What's the problem you solved?

Profile Edit was broken because I missed adding the `titlePrefix` parameter. Closes #446.

## What solution are you recommending?

Add it.