### PR TITLE
Allow GET params in /blob calls.

### DIFF
--- a/src/views/markdown.js
+++ b/src/views/markdown.js
@@ -34,8 +34,12 @@ const toUrl = (mentions) => {
     if (ssbRef.isMsgId(ref)) {
       return `/thread/${encodeURIComponent(ref)}`;
     }
-    if (ssbRef.isBlobId(ref)) {
-      return `/blob/${encodeURIComponent(ref)}`;
+    const splitIndex = ref.indexOf("?");
+    const blobRef = splitIndex === -1 ? ref : ref.slice(0, splitIndex);
+    // const blobParams = splitIndex !== -1 ? ref.slice(splitIndex) : "";
+
+    if (ssbRef.isBlobId(blobRef)) {
+      return `/blob/${encodeURIComponent(blobRef)}`;
     }
     if (ref && ref[0] === "#") {
       return `/hashtag/${encodeURIComponent(ref.substr(1))}`;


### PR DESCRIPTION
This allows blobs to load when the blob reference in the markdown has
`?contentType=image/jpeg` or similar hints attached.
It does so by simply removing the GET parameters from the URL though.
It would be a bit nicer to actually use those hints to set the right
HTTP response headers, but somehow koa keeps ignoring / overwriting (?)
the manually-set `Content-Type` headers, so this has to do for now.

## What's the problem you solved?

## What solution are you recommending?
