### PR TITLE
Use stricter regex for @mention match

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,14 +158,16 @@ const preparePreview = async function (ctx) {
   // This matches for @string followed by a space or other punctuations like ! , or .
   // The idea here is to match a plain @name but not [@name](...)
   // also: re.exec has state => regex is consumed and thus needs to be re-instantiated for each call
-  const rex = /(?!\[)@([a-zA-Z0-9-]+)([\s.,!?)~]{1}|$)/g;
-  //                                  ^ sentence ^
-  //                                   delimiters
+  //
+  // Change this link when the regex changes: https://regex101.com/r/j5rzSv/2
+  const rex = /(^|\s)(?!\[)@([a-zA-Z0-9-]+)([\s.,!?)~]{1}|$)/g;
+  //                                        ^ sentence ^
+  //                                         delimiters
 
   // find @mentions using rex and use about.named() to get the info for them
   let m;
   while ((m = rex.exec(text)) !== null) {
-    const name = m[1];
+    const name = m[2];
     let matches = about.named(name);
     for (const feed of matches) {
       let found = mentions[name] || [];


### PR DESCRIPTION
## What's the problem you solved?

Problem: You can't publish email addresses or user@host combos or
anything like that because the regex is super liberal in what it
matches.

## What solution are you recommending?

Solution: Ensure that the first word in a message is a mention *or*
ensure that there's whitespace before a mention. This also adds a
regex101 link (in lieu of proper testing, for now) which makes this
easier to test and track over time.

---

See-also: https://github.com/fraction/oasis/issues/466