### PR TITLE
Revert "Removes husky to fix #346"

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "npm test"
+  }
+}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,6 +24,9 @@ Please run `npm test` before writing a commit, because if there are errors then
 maintainers won't be able to merge your patch. Please ask for help if `npm test`
 is giving you any trouble.
 
+**Note:** `npm run fix` is run automatically as a pre-commit hook. You always
+have the option to disable pre-commit hooks with `git commit --no-verify`.
+
 ## Frequently Failed Tests
 
 ### Unknown word

--- a/package-lock.json
+++ b/package-lock.json
@@ -399,7 +399,7 @@
     },
     "@types/debug": {
       "version": "4.1.5",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
     "@types/events": {
@@ -504,7 +504,7 @@
     },
     "@types/koa-mount": {
       "version": "4.0.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-56iBULArwY3uKLl28eRFchZ2v0diEoJzJbDaHH/ehgruF/s2/KMHyWsKcIhvDJ3tGdKu9oZNQvxaMg++1IKFdA==",
       "dev": true,
       "requires": {
@@ -522,7 +522,7 @@
     },
     "@types/koa-static": {
       "version": "4.0.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-SSpct5fEcAeRkBHa3RiwCIRfDHcD1cZRhwRF///ZfvRt8KhoqRrhK6wpDlYPk/vWHVFE9hPGqh68bhzsHkir4w==",
       "dev": true,
       "requires": {
@@ -531,9 +531,9 @@
       }
     },
     "@types/koa__router": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.3.tgz",
-      "integrity": "sha512-eS8K49z1x6OaW1ha61kRksVo42L5DWdQUA3kVpH1Kz6TuKBlG0ri42ELA4zSh+xg+6fAqjfuWA7bfNvwVMNXQA==",
+      "version": "8.0.2",
+      "resolved": false,
+      "integrity": "sha512-3ZWfVAEcErHrZA31fWUC2YyZyAgoG4eKtQPy2XwBzdSpQealxjL7GcEEtGY925qPPs1wurW59qDl0KuRB39rrw==",
       "dev": true,
       "requires": {
         "@types/koa": "*"
@@ -602,9 +602,9 @@
       "dev": true
     },
     "@types/mkdirp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
-      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+      "version": "1.0.0",
+      "resolved": false,
+      "integrity": "sha512-ONFY9//bCEr3DWKON3iDv/Q8LXnhaYYaNDeFSN0AtO5o4sLf9F0pstJKKKjQhXE0kJEeHs8eR6SAsROhhc2Csw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -617,7 +617,7 @@
     },
     "@types/nodemon": {
       "version": "1.19.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-nf0PKjNv3wo0pyhlPkHjfpU2oUYMdOIsCXceiFG6kvhYxbTwn2ne9mz2iWvJ/4QtCrJUEPJLNXuyGleyTacdaw==",
       "dev": true,
       "requires": {
@@ -637,9 +637,9 @@
       "dev": true
     },
     "@types/pull-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@types/pull-stream/-/pull-stream-3.6.2.tgz",
-      "integrity": "sha512-s5jYmaJH68IQb9JjsemWUZCpaQdotd7B4xfXQtcKvGmQxcBXD/mvSQoi3TzPt2QqpDLjImxccS4en8f8E8O0FA==",
+      "version": "3.6.0",
+      "resolved": false,
+      "integrity": "sha512-d7cobAytjsYaTluqFTJopLbdZRs1HBkU+N07/zCtsXANZ5s9riDazRkvxkAUfmRzCvXqYAsGgnJHgX2lInIOQg==",
       "dev": true
     },
     "@types/qs": {
@@ -728,9 +728,9 @@
       }
     },
     "@types/yargs": {
-      "version": "15.0.10",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.10.tgz",
-      "integrity": "sha512-z8PNtlhrj7eJNLmrAivM7rjBESG6JwC5xP3RVk12i/8HVP7Xnx/sEmERnRImyEuUaJfO942X0qMOYsoupaJbZQ==",
+      "version": "15.0.4",
+      "resolved": false,
+      "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -1335,23 +1335,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-    },
-    "bytewise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-      "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
-      "requires": {
-        "bytewise-core": "^1.2.2",
-        "typewise": "^1.0.3"
-      }
-    },
-    "bytewise-core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-      "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
-      "requires": {
-        "typewise-core": "^1.2"
-      }
     },
     "cache-content-type": {
       "version": "1.0.1",
@@ -3180,6 +3163,21 @@
       "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
       "dev": true
     },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
     "execall": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
@@ -4219,6 +4217,108 @@
         "sshpk": "^1.7.0"
       }
     },
+    "husky": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.1.0.tgz",
+      "integrity": "sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "ci-info": "^2.0.0",
+        "cosmiconfig": "^5.2.1",
+        "execa": "^1.0.0",
+        "get-stdin": "^7.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^4.2.0",
+        "please-upgrade-node": "^3.2.0",
+        "read-pkg": "^5.2.0",
+        "run-node": "^1.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "dev": true,
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
     "hyperaxe": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/hyperaxe/-/hyperaxe-1.3.0.tgz",
@@ -4520,6 +4620,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "dev": true
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
     "is-docker": {
@@ -5346,111 +5452,6 @@
       "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
       "requires": {
         "ltgt": "^2.1.2"
-      }
-    },
-    "level-sublevel": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz",
-      "integrity": "sha512-SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==",
-      "requires": {
-        "bytewise": "~1.1.0",
-        "levelup": "~0.19.0",
-        "ltgt": "~2.1.1",
-        "pull-defer": "^0.2.2",
-        "pull-level": "^2.0.3",
-        "pull-stream": "^3.6.8",
-        "typewiselite": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-          "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-          "requires": {
-            "xtend": "~3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-            }
-          }
-        },
-        "bl": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-          "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-          "requires": {
-            "readable-stream": "~1.0.26"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
-          "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
-          "requires": {
-            "abstract-leveldown": "~0.12.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "levelup": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
-          "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
-          "requires": {
-            "bl": "~0.8.1",
-            "deferred-leveldown": "~0.2.0",
-            "errno": "~0.1.1",
-            "prr": "~0.0.0",
-            "readable-stream": "~1.0.26",
-            "semver": "~5.1.0",
-            "xtend": "~3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-            }
-          }
-        },
-        "ltgt": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-          "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
-        },
-        "prr": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-          "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "semver": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
-          "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
       }
     },
     "level-supports": {
@@ -6355,6 +6356,15 @@
       "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true
     },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -6691,6 +6701,12 @@
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
     "p-limit": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
@@ -6891,6 +6907,15 @@
       "dev": true,
       "requires": {
         "find-up": "^3.0.0"
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "postcss": {
@@ -8112,6 +8137,12 @@
         "is-promise": "^2.1.0"
       }
     },
+    "run-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
@@ -8196,6 +8227,12 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -8319,11 +8356,37 @@
           "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
           "optional": true
         },
+        "decompress-response": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+          "optional": true,
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+          "optional": true
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "optional": true
+        },
+        "simple-get": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
+          "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
+          "optional": true,
+          "requires": {
+            "decompress-response": "^6.0.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+          }
         }
       }
     },
@@ -8346,38 +8409,10 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
       "optional": true
-    },
-    "simple-get": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
-      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
-      "optional": true,
-      "requires": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      },
-      "dependencies": {
-        "decompress-response": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-          "optional": true,
-          "requires": {
-            "mimic-response": "^3.1.0"
-          }
-        },
-        "mimic-response": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-          "optional": true
-        }
-      }
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -8836,19 +8871,64 @@
       }
     },
     "ssb-invite": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/ssb-invite/-/ssb-invite-2.1.4.tgz",
-      "integrity": "sha512-bq4Iow4DOfsfWKE6otgD2+sWd59PcLW/WUbwZdJlukaT2m0nazPu2s8k9xX/95p+pJS7xkLyywHxMzytiKRqTg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/ssb-invite/-/ssb-invite-2.1.6.tgz",
+      "integrity": "sha512-cR2sMFu27K7JNAiHCJ5qsp5kihlxi0/KftJ58gFzQbC8kLQ9iLLFUVDvQMi/Qxubf6Xs37Qh49FH3RzPLGt9ag==",
       "requires": {
         "cont": "^1.0.3",
         "explain-error": "^1.0.4",
         "ip": "^1.1.5",
-        "level": "^5.0.0",
-        "level-sublevel": "^6.6.5",
-        "muxrpc-validation": "^3.0.0",
-        "ssb-client": "^4.7.4",
-        "ssb-keys": "^7.1.3",
-        "ssb-ref": "^2.13.9"
+        "level": "^6.0.1",
+        "muxrpc-validation": "^3.0.2",
+        "ssb-client": "^4.9.0",
+        "ssb-keys": "^7.2.2",
+        "ssb-ref": "^2.14.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "level": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
+          "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
+          "requires": {
+            "level-js": "^5.0.0",
+            "level-packager": "^5.1.0",
+            "leveldown": "^5.4.0"
+          }
+        },
+        "level-js": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
+          "integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
+          "requires": {
+            "abstract-leveldown": "~6.2.3",
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.3",
+            "ltgt": "^2.1.2"
+          }
+        },
+        "ssb-ref": {
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.14.2.tgz",
+          "integrity": "sha512-pPkwNX/Rrr0bV/8d8dC/f+T/LcKA9ZF1SGHrUuVpoqo8iE3gLMu0Zz5TRoUReXKW6+ehNzUzIjcpYTw+wWeZkA==",
+          "requires": {
+            "ip": "^1.1.3",
+            "is-canonical-base64": "^1.1.1",
+            "is-valid-domain": "~0.0.1",
+            "multiserver-address": "^1.0.1"
+          }
+        }
       }
     },
     "ssb-keys": {
@@ -9541,6 +9621,12 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
     "strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -9913,48 +9999,9 @@
         "yapool": "^1.0.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
-        "@babel/core": {
-          "version": "7.10.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.5",
-            "@babel/helper-module-transforms": "^7.10.5",
-            "@babel/helpers": "^7.10.4",
-            "@babel/parser": "^7.10.5",
-            "@babel/template": "^7.10.4",
-            "@babel/traverse": "^7.10.5",
-            "@babel/types": "^7.10.5",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.2",
-            "lodash": "^4.17.19",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "@babel/generator": {
           "version": "7.10.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/types": "^7.10.5",
             "jsesc": "^2.5.1",
@@ -9963,8 +10010,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.5.7",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
@@ -9998,7 +10044,6 @@
         "@babel/helper-function-name": {
           "version": "7.10.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.10.4",
             "@babel/template": "^7.10.4",
@@ -10008,7 +10053,6 @@
         "@babel/helper-get-function-arity": {
           "version": "7.10.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/types": "^7.10.4"
           }
@@ -10016,7 +10060,6 @@
         "@babel/helper-member-expression-to-functions": {
           "version": "7.10.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/types": "^7.10.5"
           }
@@ -10024,7 +10067,6 @@
         "@babel/helper-module-imports": {
           "version": "7.10.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/types": "^7.10.4"
           }
@@ -10032,7 +10074,6 @@
         "@babel/helper-module-transforms": {
           "version": "7.10.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/helper-module-imports": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4",
@@ -10046,7 +10087,6 @@
         "@babel/helper-optimise-call-expression": {
           "version": "7.10.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/types": "^7.10.4"
           }
@@ -10059,7 +10099,6 @@
         "@babel/helper-replace-supers": {
           "version": "7.10.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/helper-member-expression-to-functions": "^7.10.4",
             "@babel/helper-optimise-call-expression": "^7.10.4",
@@ -10070,7 +10109,6 @@
         "@babel/helper-simple-access": {
           "version": "7.10.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/template": "^7.10.4",
             "@babel/types": "^7.10.4"
@@ -10079,20 +10117,17 @@
         "@babel/helper-split-export-declaration": {
           "version": "7.10.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-validator-identifier": {
           "version": "7.10.4",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "@babel/helpers": {
           "version": "7.10.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/template": "^7.10.4",
             "@babel/traverse": "^7.10.4",
@@ -10102,7 +10137,6 @@
         "@babel/highlight": {
           "version": "7.10.4",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "chalk": "^2.0.0",
@@ -10111,8 +10145,7 @@
         },
         "@babel/parser": {
           "version": "7.10.5",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "@babel/plugin-proposal-object-rest-spread": {
           "version": "7.10.4",
@@ -10168,12 +10201,38 @@
             "@babel/plugin-syntax-jsx": "^7.10.4"
           }
         },
+        "@babel/runtime": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "requires": {
+            "@babel/generator": "^7.10.5",
+            "@babel/helper-module-transforms": "^7.10.5",
+            "@babel/helpers": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.10.5",
+            "@babel/types": "^7.10.5",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.19",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            }
+          }
+        },
         "@babel/template": {
           "version": "7.10.4",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.10.4",
             "@babel/parser": "^7.10.4",
             "@babel/types": "^7.10.4"
           }
@@ -10181,9 +10240,7 @@
         "@babel/traverse": {
           "version": "7.10.5",
           "bundled": true,
-          "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.10.4",
             "@babel/generator": "^7.10.5",
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
@@ -10197,7 +10254,6 @@
         "@babel/types": {
           "version": "7.10.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -10244,7 +10300,6 @@
         "ansi-styles": {
           "version": "3.2.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -10302,7 +10357,6 @@
         "chalk": {
           "version": "2.4.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -10334,28 +10388,24 @@
         "color-convert": {
           "version": "1.9.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "convert-source-map": {
           "version": "1.7.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.1"
           },
           "dependencies": {
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "dev": true
+              "bundled": true
             }
           }
         },
@@ -10367,7 +10417,6 @@
         "debug": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -10379,8 +10428,7 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "esprima": {
           "version": "4.0.1",
@@ -10394,18 +10442,15 @@
         },
         "gensync": {
           "version": "1.0.0-beta.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "globals": {
           "version": "11.12.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "import-jsx": {
           "version": "3.1.0",
@@ -10506,26 +10551,22 @@
         },
         "js-tokens": {
           "version": "4.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "jsesc": {
           "version": "2.5.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "json5": {
           "version": "2.1.3",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           }
         },
         "lodash": {
           "version": "4.17.19",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "lodash.throttle": {
           "version": "4.1.1",
@@ -10637,8 +10678,7 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "minipass": {
           "version": "3.1.3",
@@ -10666,8 +10706,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10684,8 +10723,7 @@
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "prop-types": {
           "version": "15.7.2",
@@ -10729,7 +10767,6 @@
         "resolve": {
           "version": "1.17.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
           }
@@ -10759,8 +10796,7 @@
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.3",
@@ -10851,7 +10887,6 @@
         "supports-color": {
           "version": "5.5.0",
           "bundled": true,
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -10876,8 +10911,7 @@
         },
         "to-fast-properties": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "treport": {
           "version": "1.0.2",
@@ -11455,19 +11489,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
-    },
-    "typewise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-      "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
-      "requires": {
-        "typewise-core": "^1.2.0"
-      }
-    },
-    "typewise-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-      "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
     },
     "typewiselite": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "nodemon --inspect src/index.js --debug --no-open",
     "fix": "common-good fix",
     "start": "node src/index.js",
-    "test": "tap --timeout 240 && common-good check --dependency-check-suffix '-i changelog-version -i mkdirp -i nodemon -i stylelint-config-recommended'",
+    "test": "tap --timeout 240 && common-good check --dependency-check-suffix '-i changelog-version -i mkdirp -i nodemon -i stylelint-config-recommended -i husky'",
     "preversion": "npm test",
     "version": "mv docs/CHANGELOG.md ./ && changelog-version && mv CHANGELOG.md docs/ && git add docs/CHANGELOG.md"
   },
@@ -95,6 +95,7 @@
     "@types/yargs": "^15.0.4",
     "changelog-version": "^2.0.0",
     "common-good": "^2.0.3",
+    "husky": "^3.0.5",
     "mkdirp": "^1.0.4",
     "nodemon": "^2.0.3",
     "stylelint-config-recommended": "^3.0.0",


### PR DESCRIPTION
## What's the problem you solved?

Problem: I keep forgetting to run tests and my commits aren't actually
passing in CI. I'd really like for these to be run automatically so that
I don't have to remember my pre-commit hooks.

## What solution are you recommending?

Solution: Revert commit d9e829e2e8eddcc7c8edae2dd542cb69d86836c1, which
Nick Wynja added to remove Husky as a pre-commit hook. I hope that
anyone who doesn't want to run the pre-commit hook will run Git with the
`--no-verify` option, and anyone bummed at this change will open a
conversation to discuss in more details (or just revert *this* commit).

---

See-also: https://github.com/fraction/oasis/issues/346




