### PR TITLE
Increase dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 16

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,9 +18,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
-      - name: Set git to not change EoL
-        run: |
-          git config --global core.autocrlf false
+      - run: git config --global core.autocrlf false
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1


### PR DESCRIPTION
Problem: 5 is not a lot and I'd rather have the builds all done and
ready when I'm ready to merge them instead of having to do them in
chunks of 5.

Solution: Allow 16 open PRs at a time. We can change as needed.