### PR TITLE
Revert CSS changes from preview PR

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -144,6 +144,7 @@ section header a {
   text-decoration: none;
   margin-right: var(--size--2);
   margin-left: var(--size--2);
+  font-weight: bold;
 }
 
 /* For use with elements specific for
@@ -156,6 +157,7 @@ section header a {
 section > footer > div > a,
 section > footer > div > form > button {
   color: var(--fg-status);
+  font-weight: bold;
 }
 
 section > footer > div > form > button {
@@ -333,6 +335,7 @@ nav {
 nav > ul > li > a {
   color: var(--fg);
   text-decoration: none;
+  font-weight: bold;
 }
 
 .author-action > a {
@@ -440,7 +443,6 @@ section > .centered-footer {
 
 section > footer {
   color: var(--fg-status);
-  margin-top: var(--size-0);
 }
 
 section > footer br {


### PR DESCRIPTION
Problem: There were lots of CSS changes in the preview + blob PR and I
didn't take enough time to look at them. It looks like a few of them
made style problems (e.g. extra specing in the 'next' / 'previous' links
on the profile pages) and it made it harder (IMO) to determine that
links are links (since we've been using font weight to distinguish).

Solution: Revert those changes back to the previous defaults. If the
margin glitch was on purpose or anyone feels strongly about
distinguishing links using some other style (color?) then I'm happy to
merge those, but I'd like to fix the extra margin and have *some* way to
distinguish links in the mean time.