### PR TITLE
Add rebuild button to settings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -710,7 +710,6 @@ router
   .get("/settings", async (ctx) => {
     const theme = ctx.cookies.get("theme") || config.theme;
     const getMeta = async ({ theme }) => {
-      const status = await meta.status();
       const peers = await meta.connectedPeers();
       const peersWithNames = await Promise.all(
         peers.map(async ([key, value]) => {
@@ -720,7 +719,6 @@ router
       );
 
       return settingsView({
-        status,
         peers: peersWithNames,
         theme,
         themeNames,
@@ -1007,6 +1005,11 @@ router
   .post("/settings/invite/accept", koaBody(), async (ctx) => {
     const invite = String(ctx.request.body.invite);
     await meta.acceptInvite(invite);
+    ctx.redirect("/settings");
+  })
+  .post("/settings/rebuild", async (ctx) => {
+    // Do not wait for rebuild to finish.
+    meta.rebuild();
     ctx.redirect("/settings");
   });
 

--- a/src/models.js
+++ b/src/models.js
@@ -586,6 +586,11 @@ module.exports = ({ cooler, isPublic }) => {
       const ssb = await cooler.open();
       return await ssb.invite.accept(invite);
     },
+    // Returns promise, does not wait for rebuild to finish.
+    rebuild: async () => {
+      const ssb = await cooler.open();
+      return ssb.rebuild();
+    },
   };
 
   const isLooseRoot = (message) => {

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -165,6 +165,8 @@ const i18n = {
     restartNetworking: "Restart networking",
     sync: "Connect and Sync",
     indexes: "Indexes",
+    indexesDescription:
+      "Oasis keeps a cache of common calculations so that we can save time. Unfortunately this is a common source of bugs. Rebuilding your indexes is safe, and may fix some types of bugs.",
     invites: "Invites",
     invitesDescription:
       "Redeem an invite by pasting it below. If it works, you'll follow the feed and they'll follow you back.",
@@ -196,6 +198,7 @@ const i18n = {
     profileDescription: "Profile description (Markdown)",
     hashtagDescription:
       "Posts from people in your network that reference this hashtag, sorted by recency.",
+    rebuildName: "Rebuild database indexes",
   },
   /* spell-checker: disable */
   es: {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -989,15 +989,7 @@ exports.previewView = ({ previewData, contentWarning }) => {
 /**
  * @param {{status: object, peers: any[], theme: string, themeNames: string[], version: string }} input
  */
-exports.settingsView = ({ status, peers, theme, themeNames, version }) => {
-  const max = status.sync.since;
-
-  const progressElements = Object.entries(status.sync.plugins).map((e) => {
-    const [key, val] = e;
-    const id = `progress-${key}`;
-    return div(label(key, progress({ id, value: val, max }, val)));
-  });
-
+exports.settingsView = ({ peers, theme, themeNames, version }) => {
   const startButton = form(
     { action: "/settings/conn/start", method: "post" },
     button({ type: "submit" }, i18n.startNetworking)
@@ -1075,6 +1067,11 @@ exports.settingsView = ({ status, peers, theme, themeNames, version }) => {
       ? option({ value: shortName, selected: true }, longName)
       : option({ value: shortName }, longName);
 
+  const rebuildButton = form(
+    { action: "/settings/rebuild", method: "post" },
+    button({ type: "submit" }, i18n.rebuildName)
+  );
+
   return template(
     i18n.settings,
     section(
@@ -1118,7 +1115,8 @@ exports.settingsView = ({ status, peers, theme, themeNames, version }) => {
         button({ type: "submit" }, i18n.setLanguage)
       ),
       h2(i18n.indexes),
-      progressElements
+      p(i18n.indexesDescription),
+      rebuildButton
     )
   );
 };


### PR DESCRIPTION
Problem: The latest release seems to have some index problems, which is
frustrating, but might be able to be circumvented with a database
rebuild. The rebuild was something that Ahau funded and I'm excited to
be able to finally expose this to users without asking them to `rm -rf`
random files in their `~/.ssb` directory.

Solution: Replaced unused 'progress' bars (always at 100%) with rebuild
button.