### PR TITLE
Hides content of messages from blocked people

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -667,6 +667,10 @@ section.post-preview > section > footer {
   display: none;
 }
 
+section.post.blocked {
+  font-style: italic;
+}
+
 section > footer > div > a:hover,
 section > footer > div > form > button:hover {
   text-decoration: underline;

--- a/src/models.js
+++ b/src/models.js
@@ -866,6 +866,11 @@ module.exports = ({ cooler, isPublic }) => {
           );
         }
 
+        const { blocking } = await models.friend.getRelationship(
+          msg.value.author
+        );
+        lodash.set(msg, "value.meta.blocking", blocking);
+
         return msg;
       })
     );

--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -75,6 +75,7 @@ const i18n = {
     relationshipFollowing: "You are following",
     relationshipYou: "This is you",
     relationshipBlocking: "You are blocking",
+    relationshipBlockingPost: "This message hides content from a blocked user.",
     relationshipNone: "You are neither following or blocking",
     relationshipConflict: "You are somehow both following and blocking",
     // author view

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -220,6 +220,7 @@ const thread = (messages) => {
       const isAncestor = Boolean(
         lodash.get(currentMsg, "value.meta.thread.ancestorOfTarget", false)
       );
+      const isBlocked = Boolean(nextMsg.value.meta.blocking);
       msgList.push(`<div class="indent"><details ${isAncestor ? "open" : ""}>`);
 
       const nextAuthor = lodash.get(nextMsg, "value.meta.author.name");
@@ -228,8 +229,13 @@ const thread = (messages) => {
           ? lodash.get(nextMsg, "value.content.contentWarning")
           : lodash.get(nextMsg, "value.content.text")
       );
-
-      msgList.push(summary(`${nextAuthor}: ${nextSnippet}`).outerHTML);
+      msgList.push(
+        summary(
+          isBlocked
+            ? i18n.relationshipBlockingPost
+            : `${nextAuthor}: ${nextSnippet}`
+        ).outerHTML
+      );
     } else if (depth(currentMsg) > depth(nextMsg)) {
       // getting more shallow
       const diffDepth = depth(currentMsg) - depth(nextMsg);
@@ -353,6 +359,7 @@ const post = ({ msg, aside = false }) => {
   };
 
   const isPrivate = Boolean(msg.value.meta.private);
+  const isBlocked = Boolean(msg.value.meta.blocking);
   const isRoot = msg.value.content.root == null;
   const isFork = msg.value.meta.postType === "subtopic";
   const hasContentWarning =
@@ -437,6 +444,17 @@ const post = ({ msg, aside = false }) => {
           })
         )
       : article({ class: "content", innerHTML: markdownContent });
+
+  if (isBlocked) {
+    messageClasses.push("blocked");
+    return section(
+      {
+        id: msg.key,
+        class: messageClasses.join(" "),
+      },
+      i18n.relationshipBlockingPost
+    );
+  }
 
   const articleContent = hasContentWarning
     ? details(summary(msg.value.content.contentWarning), articleElement)


### PR DESCRIPTION
## What's the problem you solved?

#622 

## What solution are you recommending?

This introduces a basic implementation to not display the content of
messages. It still shows that a message exists but shows localized
copy indicating why the content was hidden.

We should consider additional filters or queries in different views to actually
remove these posts but I'll leave that as up for discussion since I can see
value in showing that a blocked comment exists in a conversation.

