### PR TITLE
Adds subscribed channels to Topics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -471,7 +471,12 @@ router
   })
   .get("/public/latest/topics", async (ctx) => {
     const messages = await post.latestTopics();
-    ctx.body = await topicsView({ messages });
+    const channels = await post.channels();
+    const list = channels.map((c) => {
+      return li(a({ href: `/hashtag/${c}` }, `#${c}`));
+    });
+    const prefix = nav(ul(list));
+    ctx.body = await topicsView({ messages, prefix });
   })
   .get("/public/latest/summaries", async (ctx) => {
     const messages = await post.latestSummaries();

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1225,11 +1225,12 @@ exports.latestView = ({ messages }) => {
   });
 };
 
-exports.topicsView = ({ messages }) => {
+exports.topicsView = ({ messages, prefix }) => {
   return messageListView({
     messages,
     viewTitle: i18n.topics,
     viewDescription: i18n.topicsDescription,
+    viewElements: prefix,
   });
 };
 


### PR DESCRIPTION
## What's the problem you solved?

Subscribed channels make it easy to stay connected to topics you're interested in. Oasis doesn't display a list of topics anywhere so, as mentioned in #217, you need to access through search and then click on a hashtag.

## What solution are you recommending?

Any subscribed channels now appear at the top of Topics. This gives you
easy access to view subscribed channels using the existing hashtags
view. Much more can be done to fully support features discussed in #217 but this is a start.

![image](https://user-images.githubusercontent.com/1012017/109855103-e276c200-7c25-11eb-9323-b8ce2668428e.png)

For anyone reviewing, you can subscribe and unsubscribe to channels with these CLI commands:

```
ssb publish --type channel --channel oasis --subscribed
```
and:

```
ssb publish --type channel --channel oasis --no-subscribed
```


