### PR TITLE
docs: Fix Docker port mapping

### DIFF
--- a/docs/with-docker.md
+++ b/docs/with-docker.md
@@ -14,7 +14,7 @@ docker volume create ssb
 ## Run
 
 ```
-docker run --mount source=ssb,target=/home/node/.ssb --publish 127.0.0.0:3000:3000 --rm oasis
+docker run --mount source=ssb,target=/home/node/.ssb --publish 127.0.0.1:3000:3000 --rm oasis
 ```
 
 You should now be able to open http://localhost:3000 in your browser.


### PR DESCRIPTION
## What's the problem you solved?

The oasis wouldn't be reachable at `localhost:3000`.

## What solution are you recommending?

Use 127.0.0.1 for the host side of the mapping (localhost), rather than the incorrect 127.0.0.0.